### PR TITLE
feat: expand admin grid schema and column controls

### DIFF
--- a/apps/web/app/admin/page.tsx
+++ b/apps/web/app/admin/page.tsx
@@ -1,99 +1,585 @@
 "use client";
-import React, { useEffect, useMemo, useState } from "react";
-import VisibilityPanel from "@/components/admin/VisibilityPanel";
-import { ColumnDef, flexRender, getCoreRowModel, useReactTable } from "@tanstack/react-table";
 
-// When deployed together on Vercel, same-origin API: leave blank default
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import type { ReactNode } from "react";
+import ColumnManager, {
+  type ColumnDescriptor,
+  type ColumnLayout,
+} from "@/components/admin/ColumnManager";
+import type { VisibilityRule } from "@/components/admin/types";
+import {
+  ColumnDef,
+  flexRender,
+  getCoreRowModel,
+  getSortedRowModel,
+  type SortingState,
+  useReactTable,
+} from "@tanstack/react-table";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import {
+  formatCurrencyUSD,
+  formatDate,
+  formatNumber,
+  formatPercent,
+} from "@/lib/format";
+
 const API_BASE = process.env.NEXT_PUBLIC_API_BASE || "";
 const MAIN_TABLE = "Partner Investments";
+const LAYOUT_STORAGE_KEY = "jbv:admin:layout:v1";
 
-// Simple format helpers (replace with lib/format.ts if you split)
-const fmtCurrency = (n: any) => {
-  const val = Number(n);
-  if (!isFinite(val)) return "—";
-  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 2 }).format(val);
-};
-const fmtDate = (d: any) => {
-  const dt = d ? new Date(d) : null;
-  return dt && !isNaN(+dt) ? dt.toLocaleDateString() : "—";
+const PRIMARY_CONTACT_KEY = normalizeFieldKey("Primary Contact");
+const PARTNER_KEY = normalizeFieldKey("Partner");
+const FUND_KEY = normalizeFieldKey("Fund");
+const STATUS_KEY = normalizeFieldKey("Status");
+const STATUS_I_KEY = normalizeFieldKey("Status (I)");
+const INVESTMENT_KEY = normalizeFieldKey("Partner Investment");
+const CURRENCY_FIELD_KEYS = new Set(
+  [
+    "Commitment",
+    "Current NAV",
+    "Cost / Share",
+    "Distributions",
+    "FMV / Share",
+    "Total NAV",
+    "Gain / Loss",
+  ].map(normalizeFieldKey)
+);
+
+const DATE_FIELD_KEYS = new Set(
+  ["Paid Dates", "Period Ending"].map(normalizeFieldKey)
+);
+
+const PERCENT_FIELD_KEYS = new Set(["Percent"].map(normalizeFieldKey));
+
+const RULE_KEY = (tableId: string, normalized: string) => `${tableId}:${normalized}`;
+
+type Role = "Admin" | "LP" | "Partner";
+
+type AirtableRecord = {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime: string | null;
 };
 
-function Badge({ children }: { children: React.ReactNode }) {
-  return <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs bg-white">{children}</span>;
+type LinkedRecord = {
+  id: string;
+  displayName?: string;
+  fields?: Record<string, any>;
+  [key: string]: any;
+};
+
+type FieldValueType =
+  | "linked"
+  | "attachment"
+  | "checkbox"
+  | "currency"
+  | "number"
+  | "percent"
+  | "date"
+  | "text"
+  | "array";
+
+type FieldGroup = {
+  normalized: string;
+  fieldNames: string[];
+  displayName: string;
+  writeFieldId: string;
+  type: FieldValueType;
+};
+
+function normalizeFieldKey(name: string) {
+  return (name || "").trim().toLowerCase();
 }
-function ChipList({ value }: { value: any[] }) {
-  if (!Array.isArray(value) || value.length === 0) return <span className="text-gray-400">—</span>;
+
+function mergeLayoutWithServerFields(
+  serverOrder: string[],
+  layout?: ColumnLayout | null
+): ColumnLayout {
+  const uniqueServerOrder = Array.from(new Set(serverOrder));
+  if (!layout) {
+    return { order: uniqueServerOrder, hidden: [] };
+  }
+  const filteredOrder = layout.order.filter((id) => uniqueServerOrder.includes(id));
+  const mergedOrder = Array.from(new Set([...filteredOrder, ...uniqueServerOrder]));
+  const hidden = layout.hidden.filter((id) => mergedOrder.includes(id));
+  return { order: mergedOrder, hidden };
+}
+
+function determineDisplayName(
+  fieldNames: string[],
+  normalized: string,
+  displayNameMap: Record<string, string>
+) {
+  for (const key of fieldNames) {
+    if (displayNameMap[key]) return displayNameMap[key];
+  }
+  if (displayNameMap[normalized]) return displayNameMap[normalized];
+  const preferred = fieldNames.find((name) => name !== name.toUpperCase()) || fieldNames[0];
+  if (preferred === preferred.toUpperCase()) {
+    return preferred
+      .toLowerCase()
+      .split(/([\s/_()-]+)/)
+      .map((part) => {
+        if (!part.trim()) return part;
+        if (/^[\s/_()-]+$/.test(part)) return part;
+        if (part.length <= 3) return part.toUpperCase();
+        return part.charAt(0).toUpperCase() + part.slice(1);
+      })
+      .join("")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+  return preferred;
+}
+
+function getFieldValueByNames(
+  record: AirtableRecord,
+  fieldNames: string[],
+  normalized: string
+) {
+  const fields = record.fields || {};
+  for (const name of fieldNames) {
+    if (Object.prototype.hasOwnProperty.call(fields, name)) {
+      return fields[name];
+    }
+  }
+  for (const key of Object.keys(fields)) {
+    if (normalizeFieldKey(key) === normalized) return fields[key];
+  }
+  return undefined;
+}
+
+function inferFieldType(
+  fieldNames: string[],
+  normalized: string,
+  displayName: string,
+  records: AirtableRecord[]
+): FieldValueType {
+  const nameForHints = `${normalized} ${displayName}`.toLowerCase();
+
+  for (const rec of records) {
+    const value = getFieldValueByNames(rec, fieldNames, normalized);
+    if (value === null || value === undefined || value === "") continue;
+    if (Array.isArray(value)) {
+      if (value.length === 0) continue;
+      const first = value[0];
+      if (first && typeof first === "object") {
+        if ("url" in first) return "attachment";
+        if ("displayName" in first || "fields" in first) return "linked";
+      }
+      if (typeof first === "string") return "array";
+    } else if (typeof value === "boolean") {
+      return "checkbox";
+    } else if (typeof value === "number") {
+      if (CURRENCY_FIELD_KEYS.has(normalized)) return "currency";
+      if (PERCENT_FIELD_KEYS.has(normalized) || nameForHints.includes("percent")) return "percent";
+      return "number";
+    } else if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) {
+        if (
+          DATE_FIELD_KEYS.has(normalized) ||
+          nameForHints.includes("date") ||
+          !Number.isNaN(Date.parse(value))
+        ) {
+          return "date";
+        }
+      }
+      return "text";
+    }
+  }
+
+  if (CURRENCY_FIELD_KEYS.has(normalized) || nameForHints.includes("nav")) return "currency";
+  if (DATE_FIELD_KEYS.has(normalized) || nameForHints.includes("date")) return "date";
+  if (PERCENT_FIELD_KEYS.has(normalized) || nameForHints.includes("percent")) return "percent";
+  return "text";
+}
+
+function getLinkedDisplay(value: any): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (!item) return "";
+      if (typeof item === "string") return item;
+      if (typeof item === "object") {
+        return (
+          item.displayName ||
+          item.fields?.Name ||
+          item.fields?.["Full Name"] ||
+          item.fields?.Title ||
+          item.id ||
+          ""
+        );
+      }
+      return "";
+    })
+    .filter((str) => typeof str === "string" && str.trim().length > 0);
+}
+
+function getAttachments(value: any): { name: string; url: string }[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .map((item) => {
+      if (!item || typeof item !== "object") return null;
+      const url = item.url || item.href;
+      if (!url) return null;
+      return {
+        url,
+        name: item.filename || item.name || item.title || url,
+      };
+    })
+    .filter((item): item is { name: string; url: string } => !!item);
+}
+
+function formatValueForCsv(group: FieldGroup, value: any): string {
+  if (value === undefined || value === null) return "";
+  switch (group.type) {
+    case "linked":
+      return getLinkedDisplay(value).join("; ");
+    case "attachment":
+      return getAttachments(value)
+        .map((item) => `${item.name} (${item.url})`)
+        .join("; ");
+    case "checkbox":
+      return value ? "TRUE" : "FALSE";
+    case "currency": {
+      const num =
+        typeof value === "number"
+          ? value
+          : value !== undefined && value !== null && value !== ""
+          ? Number(value)
+          : null;
+      return num === null || Number.isNaN(num) ? "" : formatCurrencyUSD(num);
+    }
+    case "percent": {
+      const num =
+        typeof value === "number"
+          ? value
+          : value !== undefined && value !== null && value !== ""
+          ? Number(value)
+          : null;
+      return num === null || Number.isNaN(num) ? "" : formatPercent(num);
+    }
+    case "number": {
+      const num =
+        typeof value === "number"
+          ? value
+          : value !== undefined && value !== null && value !== ""
+          ? Number(value)
+          : null;
+      return num === null || Number.isNaN(num) ? "" : formatNumber(num);
+    }
+    case "date":
+      return typeof value === "string" ? value : formatDate(value);
+    case "array":
+      return Array.isArray(value) ? value.join("; ") : String(value);
+    default:
+      return typeof value === "string" ? value : String(value);
+  }
+}
+
+function csvEscape(value: string) {
+  if (value === "") return "";
+  const needsQuotes = /["\n,]/.test(value);
+  const escaped = value.replace(/"/g, '""');
+  return needsQuotes ? `"${escaped}"` : escaped;
+}
+
+function extractPrimaryContactName(
+  record: AirtableRecord,
+  group?: FieldGroup
+) {
+  if (!group) return "";
+  const value = getFieldValueByNames(record, group.fieldNames, group.normalized);
+  const names = getLinkedDisplay(value);
+  return names[0] || "";
+}
+
+type InlineTextCellProps = {
+  value: string | null | undefined;
+  onSave: (next: string) => void;
+};
+
+function InlineTextCell({ value, onSave }: InlineTextCellProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(value ?? "");
+
+  useEffect(() => {
+    if (!editing) setDraft(value ?? "");
+  }, [editing, value]);
+
+  const commit = (next: string) => {
+    onSave(next);
+    setEditing(false);
+  };
+
+  const cancel = () => {
+    setDraft(value ?? "");
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <input
+        autoFocus
+        className="w-full rounded border px-2 py-1 text-sm"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => commit(draft)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit(draft);
+          if (e.key === "Escape") cancel();
+        }}
+      />
+    );
+  }
+
+  const display = value && value.trim() !== "" ? value : "—";
+  return (
+    <button
+      type="button"
+      className="w-full rounded border border-transparent px-2 py-1 text-left text-sm text-slate-700 hover:border-blue-200"
+      onClick={() => setEditing(true)}
+    >
+      {display}
+    </button>
+  );
+}
+
+type InlineNumberCellProps = {
+  value: number | null | undefined;
+  onSave: (next: number | null) => void;
+  format: (val: number) => string;
+};
+
+function InlineNumberCell({ value, onSave, format }: InlineNumberCellProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(
+    value === null || value === undefined ? "" : String(value)
+  );
+
+  useEffect(() => {
+    if (!editing) {
+      setDraft(value === null || value === undefined ? "" : String(value));
+    }
+  }, [editing, value]);
+
+  const commit = (raw: string) => {
+    const trimmed = raw.trim();
+    if (trimmed === "") {
+      onSave(null);
+    } else {
+      const next = Number(trimmed);
+      onSave(Number.isNaN(next) ? null : next);
+    }
+    setEditing(false);
+  };
+
+  const cancel = () => {
+    setDraft(value === null || value === undefined ? "" : String(value));
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <input
+        autoFocus
+        type="number"
+        className="w-full rounded border px-2 py-1 text-sm"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => commit(draft)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit(draft);
+          if (e.key === "Escape") cancel();
+        }}
+      />
+    );
+  }
+
+  const display =
+    value === null || value === undefined ? "—" : format(value);
+
+  return (
+    <button
+      type="button"
+      className="w-full rounded border border-transparent px-2 py-1 text-left text-sm text-slate-700 hover:border-blue-200"
+      onClick={() => setEditing(true)}
+    >
+      {display}
+    </button>
+  );
+}
+
+type InlineDateCellProps = {
+  value: string | null | undefined;
+  onSave: (next: string | null) => void;
+};
+
+function toDateInputValue(value: string | null | undefined) {
+  if (!value) return "";
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+  return parsed.toISOString().slice(0, 10);
+}
+
+function InlineDateCell({ value, onSave }: InlineDateCellProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(toDateInputValue(value));
+
+  useEffect(() => {
+    if (!editing) setDraft(toDateInputValue(value));
+  }, [editing, value]);
+
+  const commit = (raw: string) => {
+    onSave(raw ? raw : null);
+    setEditing(false);
+  };
+
+  const cancel = () => {
+    setDraft(toDateInputValue(value));
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <input
+        autoFocus
+        type="date"
+        className="w-full rounded border px-2 py-1 text-sm"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={() => commit(draft)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") commit(draft);
+          if (e.key === "Escape") cancel();
+        }}
+      />
+    );
+  }
+
+  const display = value ? formatDate(value) : "—";
+  return (
+    <button
+      type="button"
+      className="w-full rounded border border-transparent px-2 py-1 text-left text-sm text-slate-700 hover:border-blue-200"
+      onClick={() => setEditing(true)}
+    >
+      {display}
+    </button>
+  );
+}
+
+type CheckboxCellProps = {
+  value: boolean | undefined;
+  onSave: (next: boolean) => void;
+};
+
+function CheckboxCell({ value, onSave }: CheckboxCellProps) {
+  return (
+    <label className="inline-flex items-center gap-2 text-sm">
+      <input
+        type="checkbox"
+        checked={!!value}
+        onChange={(e) => onSave(e.target.checked)}
+      />
+    </label>
+  );
+}
+
+function Badge({ children }: { children: ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded-full border px-2 py-0.5 text-xs">
+      {children}
+    </span>
+  );
+}
+
+function ChipList({ value }: { value: any }) {
+  const items = getLinkedDisplay(value);
+  if (!items.length) return <span className="text-xs text-gray-400">—</span>;
   return (
     <div className="flex flex-wrap gap-1">
-      {value.map((v: any) => (
-        <Badge key={v.id || v.displayName}>{v.displayName || v.fields?.Name || v.id}</Badge>
+      {items.map((item) => (
+        <Badge key={item}>{item}</Badge>
       ))}
     </div>
   );
 }
 
-// --- Inline editors (minimal examples; expand as needed) ---
-function TextCell({ value, onSave }: { value: any; onSave: (val: string) => void }) {
-  const [v, setV] = useState(value ?? "");
+function AttachmentList({ value }: { value: any }) {
+  const files = getAttachments(value);
+  if (!files.length) return <span className="text-xs text-gray-400">—</span>;
   return (
-    <input
-      className="w-full rounded border px-2 py-1"
-      value={v}
-      onChange={(e) => setV(e.target.value)}
-      onBlur={() => onSave(v)}
-      onKeyDown={(e) => e.key === "Enter" && onSave(v)}
-    />
-  );
-}
-
-function NumberCell({ value, onSave }: { value: any; onSave: (val: number | null) => void }) {
-  const [v, setV] = useState(value ?? "");
-  return (
-    <input
-      type="number"
-      className="w-full rounded border px-2 py-1"
-      value={v}
-      onChange={(e) => setV(e.target.value)}
-      onBlur={() => onSave(v === "" ? null : Number(v))}
-      onKeyDown={(e) => e.key === "Enter" && onSave(v === "" ? null : Number(v))}
-    />
+    <ul className="space-y-1">
+      {files.map((file) => (
+        <li key={file.url}>
+          <a
+            className="text-sm text-blue-600 underline"
+            href={file.url}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {file.name}
+          </a>
+        </li>
+      ))}
+    </ul>
   );
 }
 
 export default function AdminPage() {
-  const [raw, setRaw] = useState<any[]>([]);
+  const [raw, setRaw] = useState<AirtableRecord[]>([]);
+  const [fieldOrder, setFieldOrder] = useState<string[]>([]);
+  const [displayNameMap, setDisplayNameMap] = useState<Record<string, string>>({});
   const [query, setQuery] = useState("");
   const [status, setStatus] = useState("Idle");
   const [isLoading, setIsLoading] = useState(true);
-  const [impersonation, setImpersonation] = useState<"Admin" | "LP" | "Partner">("Admin");
-  // Visibility rule shape used by the panel and filtering
-  type Rule = {
-    id?: string;
-    tableId: string;
-    fieldId: string;
-    visibleToLP: boolean;
-    visibleToPartners: boolean;
-    notes?: string;
-  };
-  const [rules, setRules] = useState<Record<string, Rule>>({});
+  const [impersonation, setImpersonation] = useState<Role>("Admin");
+  const [rules, setRules] = useState<Record<string, VisibilityRule>>({});
+  const [layoutState, setLayoutState] = useState<ColumnLayout | null>(null);
+  const [sorting, setSorting] = useState<SortingState>([
+    { id: PRIMARY_CONTACT_KEY, desc: false },
+  ]);
 
-  // Load visibility rules and normalize map by `${tableId}:${fieldId}`
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const stored = window.localStorage.getItem(LAYOUT_STORAGE_KEY);
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (parsed && typeof parsed === "object") setLayoutState(parsed);
+      }
+    } catch (e) {
+      console.warn("Failed to parse layout state", e);
+    }
+  }, []);
+
   useEffect(() => {
     (async () => {
       try {
-        const r = await fetch(`${API_BASE}/api/visibility/rules`, { cache: "no-store" });
-        const arr = await r.json();
-        const map: Record<string, Rule> = {};
+        const res = await fetch(`${API_BASE}/api/visibility/rules`, {
+          cache: "no-store",
+        });
+        const arr = await res.json();
+        const map: Record<string, VisibilityRule> = {};
         for (const rec of arr || []) {
-          const rule: Rule = {
+          const normalizedFieldId = normalizeFieldKey(rec.fieldId || "");
+          map[RULE_KEY(rec.tableId || MAIN_TABLE, normalizedFieldId)] = {
             id: rec.id,
             tableId: rec.tableId || MAIN_TABLE,
             fieldId: rec.fieldId,
+            normalizedFieldId,
             visibleToLP: !!rec.visibleToLP,
             visibleToPartners: !!rec.visibleToPartners,
-            notes: rec.notes || "",
+            notes: rec.notes,
           };
-          map[`${rule.tableId}:${rule.fieldId}`] = rule;
         }
         setRules(map);
       } catch (e) {
@@ -102,7 +588,6 @@ export default function AdminPage() {
     })();
   }, []);
 
-  // Polling for data (10s) + on window focus
   useEffect(() => {
     let killed = false;
     let lastFetch = 0;
@@ -112,9 +597,14 @@ export default function AdminPage() {
         setStatus("Refreshing…");
         const res = await fetch(`${API_BASE}/api/data`, { cache: "no-store" });
         const json = await res.json();
-        if (!killed) setRaw(json.records || json.data || []);
-        if (!killed) setStatus("Idle");
-      } catch {
+        if (!killed) {
+          setRaw(json.records || []);
+          setFieldOrder(json.fieldOrder || []);
+          setDisplayNameMap(json.displayNameMap || {});
+          setStatus("Idle");
+        }
+      } catch (e) {
+        console.error(e);
         if (!killed) setStatus("Error");
       } finally {
         if (!killed) setIsLoading(false);
@@ -131,146 +621,473 @@ export default function AdminPage() {
 
     fetchData();
     const id = setInterval(tick, 10000);
-    if (typeof window !== 'undefined') window.addEventListener("focus", tick);
+    if (typeof window !== "undefined") {
+      window.addEventListener("focus", tick);
+    }
     return () => {
       killed = true;
       clearInterval(id);
-      if (typeof window !== 'undefined') window.removeEventListener("focus", tick);
+      if (typeof window !== "undefined") {
+        window.removeEventListener("focus", tick);
+      }
     };
   }, []);
 
-  // Save helper: PUT /api/record
-  async function saveField(record: any, fieldName: string, value: any) {
-    const body = {
-      tableIdOrName: MAIN_TABLE,
-      recordId: record.id,
-      fields: { [fieldName]: value },
-      lastSeenModifiedTime: record._updatedTime || null,
+  const fieldStructure = useMemo(() => {
+    const order: string[] = [];
+    const map = new Map<string, { normalized: string; fieldNames: string[] }>();
+
+    const register = (fieldName: string) => {
+      if (!fieldName) return;
+      const normalized = normalizeFieldKey(fieldName);
+      const existing = map.get(normalized);
+      if (existing) {
+        if (!existing.fieldNames.includes(fieldName)) {
+          existing.fieldNames.push(fieldName);
+        }
+      } else {
+        map.set(normalized, { normalized, fieldNames: [fieldName] });
+        order.push(normalized);
+      }
     };
-    const res = await fetch(`${API_BASE}/api/record`, { method: "PUT", headers: { "Content-Type": "application/json" }, body: JSON.stringify(body) });
-    if (res.status === 409) {
-      alert("Conflict: this record was updated elsewhere. Refreshing row.");
-      const fresh = await res.json();
-      setRaw((prev) => prev.map((r) => (r.id === record.id ? fresh : r)));
+
+    for (const name of fieldOrder) register(name);
+    for (const rec of raw) {
+      for (const key of Object.keys(rec.fields || {})) register(key);
+    }
+
+    return { order, map };
+  }, [fieldOrder, raw]);
+
+  const fieldGroups = useMemo(() => {
+    const groups = new Map<string, FieldGroup>();
+    for (const normalized of fieldStructure.order) {
+      const entry = fieldStructure.map.get(normalized);
+      if (!entry) continue;
+      const displayName = determineDisplayName(
+        entry.fieldNames,
+        normalized,
+        displayNameMap
+      );
+      const existingRule = rules[RULE_KEY(MAIN_TABLE, normalized)];
+      const writeFieldId = existingRule?.fieldId || entry.fieldNames[0];
+      const type = inferFieldType(entry.fieldNames, normalized, displayName, raw);
+      groups.set(normalized, {
+        normalized,
+        fieldNames: entry.fieldNames,
+        displayName,
+        writeFieldId,
+        type,
+      });
+    }
+    return { order: fieldStructure.order, map: groups };
+  }, [displayNameMap, fieldStructure, raw, rules]);
+
+  const effectiveLayout = useMemo(
+    () => mergeLayoutWithServerFields(fieldGroups.order, layoutState),
+    [fieldGroups.order, layoutState]
+  );
+
+  const handleLayoutChange = useCallback(
+    (next: ColumnLayout) => {
+      const merged = mergeLayoutWithServerFields(fieldGroups.order, next);
+      setLayoutState(merged);
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(LAYOUT_STORAGE_KEY, JSON.stringify(merged));
+      }
+    },
+    [fieldGroups.order]
+  );
+
+  const columnDescriptors: ColumnDescriptor[] = useMemo(
+    () =>
+      fieldGroups.order
+        .map((normalized) => {
+          const group = fieldGroups.map.get(normalized);
+          if (!group) return null;
+          return { normalizedId: normalized, label: group.displayName };
+        })
+        .filter((item): item is ColumnDescriptor => !!item),
+    [fieldGroups]
+  );
+
+  const visibleColumns = useMemo(() => {
+    const hiddenSet = new Set(effectiveLayout.hidden);
+    return effectiveLayout.order.filter((id) => {
+      if (!fieldGroups.map.has(id)) return false;
+      if (hiddenSet.has(id)) return false;
+      if (impersonation === "Admin") return true;
+      const rule = rules[RULE_KEY(MAIN_TABLE, id)];
+      if (!rule) return true;
+      return impersonation === "LP"
+        ? !!rule.visibleToLP
+        : !!rule.visibleToPartners;
+    });
+  }, [effectiveLayout, fieldGroups.map, impersonation, rules]);
+
+  const primaryContactGroup = fieldGroups.map.get(PRIMARY_CONTACT_KEY);
+
+  const filteredRows = useMemo(() => {
+    if (!query) return raw;
+    const lower = query.toLowerCase();
+    return raw.filter((rec) => {
+      const investment = getFieldValueByNames(
+        rec,
+        fieldGroups.map.get(INVESTMENT_KEY)?.fieldNames || ["Partner Investment"],
+        INVESTMENT_KEY
+      );
+      const partner = getFieldValueByNames(
+        rec,
+        fieldGroups.map.get(PARTNER_KEY)?.fieldNames || ["Partner"],
+        PARTNER_KEY
+      );
+      const fund = getFieldValueByNames(
+        rec,
+        fieldGroups.map.get(FUND_KEY)?.fieldNames || ["Fund"],
+        FUND_KEY
+      );
+      const statusValue =
+        getFieldValueByNames(
+          rec,
+          fieldGroups.map.get(STATUS_KEY)?.fieldNames || ["Status"],
+          STATUS_KEY
+        ) ||
+        getFieldValueByNames(
+          rec,
+          fieldGroups.map.get(STATUS_I_KEY)?.fieldNames || ["Status (I)"],
+          STATUS_I_KEY
+        );
+      const primaryContact = extractPrimaryContactName(rec, primaryContactGroup);
+      const haystack = [
+        investment,
+        getLinkedDisplay(partner).join(" "),
+        getLinkedDisplay(fund).join(" "),
+        typeof statusValue === "string" ? statusValue : "",
+        primaryContact,
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(lower);
+    });
+  }, [fieldGroups.map, primaryContactGroup, query, raw]);
+
+  const resolveWriteFieldId = useCallback(
+    (record: AirtableRecord, group: FieldGroup) => {
+      for (const name of group.fieldNames) {
+        if (Object.prototype.hasOwnProperty.call(record.fields || {}, name)) {
+          return name;
+        }
+      }
+      return group.writeFieldId || group.fieldNames[0];
+    },
+    []
+  );
+
+  const saveField = useCallback(
+    async (record: AirtableRecord, group: FieldGroup, value: any) => {
+      const fieldId = resolveWriteFieldId(record, group);
+      if (!fieldId) return;
+      const body = {
+        tableIdOrName: MAIN_TABLE,
+        recordId: record.id,
+        fields: { [fieldId]: value },
+        lastSeenModifiedTime: record._updatedTime || null,
+      };
+      const res = await fetch(`${API_BASE}/api/record`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        if (res.status === 409) {
+          const fresh = await res.json();
+          setRaw((prev) =>
+            prev.map((r) => (r.id === record.id ? fresh : r))
+          );
+          alert("Record was updated elsewhere. Refreshed row.");
+        } else {
+          const err = await res.json().catch(() => ({}));
+          console.error("Failed to save field", err);
+          alert("Failed to save field. Please try again.");
+        }
+        return;
+      }
+      const updated = await res.json();
+      setRaw((prev) =>
+        prev.map((r) => {
+          if (r.id !== record.id) return r;
+          const nextFields = { ...r.fields };
+          nextFields[fieldId] = value;
+          return {
+            ...r,
+            fields: nextFields,
+            _updatedTime: updated?._updatedTime ?? r._updatedTime,
+          };
+        })
+      );
+    },
+    [resolveWriteFieldId]
+  );
+
+  const updateRuleVisibility = useCallback(
+    async (
+      normalizedId: string,
+      visibility: { visibleToLP: boolean; visibleToPartners: boolean }
+    ) => {
+      const group = fieldGroups.map.get(normalizedId);
+      const fallbackFieldId = group?.writeFieldId || normalizedId;
+      const existing = rules[RULE_KEY(MAIN_TABLE, normalizedId)];
+      const fieldId = existing?.fieldId || fallbackFieldId;
+      const payload = {
+        tableId: MAIN_TABLE,
+        fieldId,
+        visibleToLP: visibility.visibleToLP,
+        visibleToPartners: visibility.visibleToPartners,
+      };
+      const res = await fetch(`${API_BASE}/api/visibility/rules`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) throw new Error("Failed to update visibility rule");
+      const saved = await res.json();
+      const normalizedFieldId = normalizeFieldKey(saved.fieldId || fieldId);
+      const rule: VisibilityRule = {
+        id: saved.id,
+        tableId: saved.tableId || MAIN_TABLE,
+        fieldId: saved.fieldId || fieldId,
+        normalizedFieldId,
+        visibleToLP: !!saved.visibleToLP,
+        visibleToPartners: !!saved.visibleToPartners,
+        notes: saved.notes,
+      };
+      setRules((prev) => ({
+        ...prev,
+        [RULE_KEY(MAIN_TABLE, normalizedFieldId)]: rule,
+      }));
+    },
+    [fieldGroups.map, rules]
+  );
+
+  const columns = useMemo<ColumnDef<AirtableRecord>[]>(() => {
+    const defs: ColumnDef<AirtableRecord>[] = [];
+    for (const normalized of visibleColumns) {
+      const group = fieldGroups.map.get(normalized);
+      if (!group) continue;
+      defs.push({
+        id: normalized,
+        header: group.displayName,
+        accessorFn: (row) =>
+          getFieldValueByNames(row, group.fieldNames, group.normalized),
+        cell: (ctx) => {
+          const row = ctx.row.original;
+          const value = ctx.getValue();
+          switch (group.type) {
+            case "linked":
+              return <ChipList value={value} />;
+            case "attachment":
+              return <AttachmentList value={value} />;
+            case "checkbox":
+              return (
+                <CheckboxCell
+                  value={!!value}
+                  onSave={(next) => saveField(row, group, next)}
+                />
+              );
+            case "currency": {
+              const numericValue =
+                typeof value === "number"
+                  ? value
+                  : value !== undefined && value !== null && value !== ""
+                  ? Number(value)
+                  : null;
+              const safeValue =
+                typeof numericValue === "number" && Number.isFinite(numericValue)
+                  ? numericValue
+                  : null;
+              return (
+                <InlineNumberCell
+                  value={safeValue}
+                  onSave={(next) => saveField(row, group, next)}
+                  format={(val) => formatCurrencyUSD(val)}
+                />
+              );
+            }
+            case "number": {
+              const numericValue =
+                typeof value === "number"
+                  ? value
+                  : value !== undefined && value !== null && value !== ""
+                  ? Number(value)
+                  : null;
+              const safeValue =
+                typeof numericValue === "number" && Number.isFinite(numericValue)
+                  ? numericValue
+                  : null;
+              return (
+                <InlineNumberCell
+                  value={safeValue}
+                  onSave={(next) => saveField(row, group, next)}
+                  format={(val) => formatNumber(val)}
+                />
+              );
+            }
+            case "percent": {
+              const numericValue =
+                typeof value === "number"
+                  ? value
+                  : value !== undefined && value !== null && value !== ""
+                  ? Number(value)
+                  : null;
+              const safeValue =
+                typeof numericValue === "number" && Number.isFinite(numericValue)
+                  ? numericValue
+                  : null;
+              return (
+                <InlineNumberCell
+                  value={safeValue}
+                  onSave={(next) => saveField(row, group, next)}
+                  format={(val) => formatPercent(val)}
+                />
+              );
+            }
+            case "date":
+              return (
+                <InlineDateCell
+                  value={typeof value === "string" ? value : undefined}
+                  onSave={(next) => saveField(row, group, next)}
+                />
+              );
+            case "array":
+              return (
+                <span className="text-sm text-slate-700">
+                  {Array.isArray(value) && value.length
+                    ? value.join(", ")
+                    : "—"}
+                </span>
+              );
+            default:
+              return (
+                <InlineTextCell
+                  value={
+                    typeof value === "string"
+                      ? value
+                      : value !== undefined && value !== null
+                      ? String(value)
+                      : ""
+                  }
+                  onSave={(next) => saveField(row, group, next)}
+                />
+              );
+          }
+        },
+        sortingFn:
+          normalized === PRIMARY_CONTACT_KEY
+            ? (a, b) => {
+                const aName = extractPrimaryContactName(
+                  a.original,
+                  primaryContactGroup
+                );
+                const bName = extractPrimaryContactName(
+                  b.original,
+                  primaryContactGroup
+                );
+                return aName.localeCompare(bName);
+              }
+            : undefined,
+        meta: group,
+      });
+    }
+    return defs;
+  }, [fieldGroups.map, primaryContactGroup, saveField, visibleColumns]);
+
+  const table = useReactTable({
+    data: filteredRows,
+    columns,
+    state: { sorting },
+    onSortingChange: setSorting,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+  });
+
+  const tableContainerRef = useRef<HTMLDivElement>(null);
+  const rowModel = table.getRowModel().rows;
+  const rowVirtualizer = useVirtualizer({
+    count: rowModel.length,
+    getScrollElement: () => tableContainerRef.current,
+    estimateSize: () => 56,
+    overscan: 12,
+  });
+  const virtualRows = rowVirtualizer.getVirtualItems();
+  const paddingTop = virtualRows.length > 0 ? virtualRows[0].start : 0;
+  const paddingBottom =
+    virtualRows.length > 0
+      ? rowVirtualizer.getTotalSize() -
+        virtualRows[virtualRows.length - 1].end
+      : 0;
+
+  const exportCsv = useCallback(() => {
+    if (!visibleColumns.length) {
+      alert("No visible columns to export.");
       return;
     }
-    const updated = await res.json();
-    setRaw((prev) => prev.map((r) => (r.id === record.id ? updated : r)));
-  }
-
-  // visibility gate: return false to hide a column in LP/Partner modes
-  function isVisible(fieldName: string) {
-    if (impersonation === "Admin") return true;
-    const key = `${MAIN_TABLE}:${fieldName}`;
-    const rule = rules[key];
-    if (!rule) return true; // default visible
-    return impersonation === "LP" ? !!rule.visibleToLP : !!rule.visibleToPartners;
-  }
-
-  // filter rows by search
-  const rows = useMemo(() => {
-    if (!query) return raw;
-    const q = query.toLowerCase();
-    return raw.filter((r: any) => {
-      const f = r.fields || {};
-      const hay = [
-        f["Partner Investment"],
-        Array.isArray(f["Partner"]) ? f["Partner"].map((x: any) => x.displayName).join(",") : "",
-        Array.isArray(f["Fund"]) ? f["Fund"].map((x: any) => x.displayName).join(",") : "",
-        f["Status"] || f["Status (I)"]
-      ].filter(Boolean).join(" ").toLowerCase();
-      return hay.includes(q);
+    const headers = visibleColumns.map((id) =>
+      fieldGroups.map.get(id)?.displayName || id
+    );
+    const rows = filteredRows.map((record) =>
+      visibleColumns.map((id) => {
+        const group = fieldGroups.map.get(id);
+        if (!group) return "";
+        const value = getFieldValueByNames(
+          record,
+          group.fieldNames,
+          group.normalized
+        );
+        return csvEscape(formatValueForCsv(group, value));
+      })
+    );
+    const csvContent = [headers.map(csvEscape), ...rows]
+      .map((row) => row.join(","))
+      .join("\n");
+    const blob = new Blob([csvContent], {
+      type: "text/csv;charset=utf-8;",
     });
-  }, [raw, query]);
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `partner-investments-${new Date()
+      .toISOString()
+      .slice(0, 10)}.csv`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    URL.revokeObjectURL(url);
+  }, [fieldGroups.map, filteredRows, visibleColumns]);
 
-  const columns = useMemo<ColumnDef<any>[]>(() => {
-    const cols: ColumnDef<any>[] = [];
-
-    if (isVisible("Partner Investment")) cols.push({
-      header: "Investment",
-      accessorFn: (r) => r?.fields?.["Partner Investment"] ?? "—",
-      cell: (ctx) => (
-        <TextCell
-          value={ctx.getValue() as string}
-          onSave={(val) => saveField(ctx.row.original, "Partner Investment", val)}
-        />
-      ),
-    });
-
-    if (isVisible("Partner")) cols.push({
-      header: "Partner",
-      accessorFn: (r) => r?.fields?.["Partner"],
-      cell: (ctx) => <ChipList value={(ctx.getValue() as any[]) || []} />,
-    });
-
-    if (isVisible("Fund")) cols.push({
-      header: "Fund",
-      accessorFn: (r) => r?.fields?.["Fund"],
-      cell: (ctx) => <ChipList value={(ctx.getValue() as any[]) || []} />,
-    });
-
-    if (isVisible("Commitment")) cols.push({
-      header: "Commitment",
-      accessorFn: (r) => r?.fields?.["Commitment"],
-      cell: (ctx) => (
-        <NumberCell
-          value={ctx.getValue() as number}
-          onSave={(val) => saveField(ctx.row.original, "Commitment", val)}
-        />
-      ),
-    });
-
-    if (isVisible("Current NAV")) cols.push({
-      header: "Current NAV",
-      accessorFn: (r) => r?.fields?.["Current NAV"],
-      cell: (ctx) => <span>{fmtCurrency(ctx.getValue())}</span>,
-    });
-
-    if (isVisible("Status")) cols.push({
-      header: "Status",
-      accessorFn: (r) => r?.fields?.["Status"] ?? r?.fields?.["Status (I)"] ?? "—",
-      cell: (ctx) => <TextCell value={ctx.getValue() as string} onSave={(val) => saveField(ctx.row.original, "Status", val)} />,
-    });
-
-    if (isVisible("PRIMARY CONTACT")) cols.push({
-      header: "Primary Contact",
-      accessorFn: (r) => r?.fields?.["PRIMARY CONTACT"] ?? r?.fields?.["Primary Contact"],
-      cell: (ctx) => <ChipList value={(ctx.getValue() as any[]) || []} />,
-    });
-
-    if (isVisible("Updated")) cols.push({
-      header: "Updated",
-      accessorFn: (r) => r?._updatedTime,
-      cell: (ctx) => <span className="text-gray-500">{fmtDate(ctx.getValue())}</span>,
-    });
-
-    return cols;
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [impersonation, rules]);
-
-  const table = useReactTable({ data: rows, columns, getCoreRowModel: getCoreRowModel() });
+  const columnCount = table.getVisibleLeafColumns().length || columns.length || 1;
+  const recordCount = filteredRows.length;
 
   return (
     <div className="min-h-screen bg-white text-slate-900">
       <header className="sticky top-0 z-10 border-b bg-white/90 backdrop-blur">
-        <div className="mx-auto max-w-7xl px-6 py-4 flex items-center gap-4">
+        <div className="mx-auto flex max-w-7xl items-center gap-4 px-6 py-4">
           <div className="flex items-center gap-2">
             <div className="h-7 w-7 rounded bg-[#2563EB]" />
             <h1 className="text-xl font-semibold">JBV Investment Platform</h1>
             <span className="text-gray-400">·</span>
             <span className="text-slate-600">Admin · Partner Investments</span>
           </div>
-
           <div className="ml-auto flex items-center gap-3">
             <select
               className="rounded-lg border px-2 py-1"
               value={impersonation}
-              onChange={(e) => setImpersonation(e.target.value as any)}
+              onChange={(e) => setImpersonation(e.target.value as Role)}
               title="Impersonation Preview"
             >
-              <option>Admin</option>
-              <option>LP</option>
-              <option>Partner</option>
+              <option value="Admin">Admin</option>
+              <option value="LP">LP</option>
+              <option value="Partner">Partner</option>
             </select>
             <span className="text-sm text-gray-500">Refresh: {status}</span>
           </div>
@@ -278,25 +1095,53 @@ export default function AdminPage() {
       </header>
 
       <main className="mx-auto max-w-7xl px-6 py-6">
-        <div className="mb-4 flex items-center gap-3">
+        <div className="mb-4 flex flex-col gap-3 md:flex-row md:items-center md:gap-4">
           <input
-            placeholder="Search partner, fund, status…"
+            placeholder="Search partner, fund, status, contact…"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            className="w-full md:w-96 rounded-xl border px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-200"
+            className="w-full rounded-xl border px-3 py-2 shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-200 md:w-96"
           />
-          <span className="text-sm text-gray-500">{rows.length} records</span>
-          <VisibilityPanel tableId={MAIN_TABLE} rules={rules} onChangeRules={setRules} />
+          <span className="text-sm text-gray-500">{recordCount} records</span>
+          <div className="flex flex-1 items-center justify-end gap-2">
+            <button
+              type="button"
+              className="rounded-lg border bg-white px-3 py-2 text-sm shadow-sm hover:bg-blue-50"
+              onClick={exportCsv}
+            >
+              Export CSV
+            </button>
+            <ColumnManager
+              tableId={MAIN_TABLE}
+              columns={columnDescriptors}
+              layout={effectiveLayout}
+              onLayoutChange={handleLayoutChange}
+              rules={rules}
+              onRuleChange={updateRuleVisibility}
+            />
+          </div>
         </div>
 
-        <div className="overflow-hidden rounded-2xl border shadow-sm">
-          <table className="w-full border-collapse">
-            <thead className="bg-blue-50">
+        <div
+          ref={tableContainerRef}
+          className="overflow-auto rounded-2xl border shadow-sm"
+          style={{ maxHeight: "calc(100vh - 220px)" }}
+        >
+          <table className="min-w-full border-collapse">
+            <thead className="sticky top-0 z-10 bg-blue-50">
               {table.getHeaderGroups().map((hg) => (
                 <tr key={hg.id}>
-                  {hg.headers.map((h) => (
-                    <th key={h.id} className="px-3 py-2 text-left text-sm font-medium text-slate-700 border-b">
-                      {h.isPlaceholder ? null : flexRender(h.column.columnDef.header, h.getContext())}
+                  {hg.headers.map((header) => (
+                    <th
+                      key={header.id}
+                      className="border-b px-3 py-2 text-left text-sm font-semibold text-slate-700"
+                    >
+                      {header.isPlaceholder
+                        ? null
+                        : flexRender(
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
                     </th>
                   ))}
                 </tr>
@@ -304,19 +1149,61 @@ export default function AdminPage() {
             </thead>
             <tbody>
               {isLoading ? (
-                <tr><td colSpan={table.getAllColumns().length} className="px-3 py-10 text-center text-gray-400">Loading…</td></tr>
-              ) : table.getRowModel().rows.length === 0 ? (
-                <tr><td colSpan={table.getAllColumns().length} className="px-3 py-10 text-center text-gray-400">No records</td></tr>
+                <tr>
+                  <td
+                    colSpan={columnCount}
+                    className="px-3 py-10 text-center text-gray-400"
+                  >
+                    Loading…
+                  </td>
+                </tr>
+              ) : rowModel.length === 0 ? (
+                <tr>
+                  <td
+                    colSpan={columnCount}
+                    className="px-3 py-10 text-center text-gray-400"
+                  >
+                    No records
+                  </td>
+                </tr>
               ) : (
-                table.getRowModel().rows.map((row) => (
-                  <tr key={row.id} className="hover:bg-blue-50/40">
-                    {row.getVisibleCells().map((cell) => (
-                      <td key={cell.id} className="px-3 py-2 text-sm border-b align-top">
-                        {flexRender(cell.column.columnDef.cell, cell.getContext())}
-                      </td>
-                    ))}
-                  </tr>
-                ))
+                <>
+                  {paddingTop > 0 && (
+                    <tr>
+                      <td colSpan={columnCount} style={{ height: paddingTop }} />
+                    </tr>
+                  )}
+                  {virtualRows.map((virtualRow) => {
+                    const row = rowModel[virtualRow.index];
+                    return (
+                      <tr
+                        key={row.id}
+                        className="hover:bg-blue-50/40"
+                        style={{ height: virtualRow.size }}
+                      >
+                        {row.getVisibleCells().map((cell) => (
+                          <td
+                            key={cell.id}
+                            className="px-3 py-2 text-sm text-slate-700 align-top"
+                          >
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext()
+                            )}
+                          </td>
+                        ))}
+                      </tr>
+                    );
+                  })}
+                  {paddingBottom > 0 && (
+                    <tr>
+                      <td
+                        colSpan={columnCount}
+                        style={{ height: paddingBottom }}
+                      />
+                    </tr>
+                  )}
+                </>
               )}
             </tbody>
           </table>
@@ -325,3 +1212,4 @@ export default function AdminPage() {
     </div>
   );
 }
+

--- a/apps/web/app/api/data/route.ts
+++ b/apps/web/app/api/data/route.ts
@@ -72,6 +72,29 @@ type ExpandedRecord = {
   _updatedTime: string | null;
 };
 
+function normalizeFieldKey(name: string) {
+  return (name || "").trim().toLowerCase();
+}
+
+function toDisplayLabel(name: string) {
+  if (!name) return name;
+  if (name === name.toUpperCase()) {
+    return name
+      .toLowerCase()
+      .split(/([\s/_()-]+)/)
+      .map((part) => {
+        if (!part.trim()) return part;
+        if (/^[\s/_()-]+$/.test(part)) return part;
+        if (part.length <= 3) return part.toUpperCase();
+        return part.charAt(0).toUpperCase() + part.slice(1);
+      })
+      .join("")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+  return name;
+}
+
 async function expandRecords(rows: AirtableRecord[]): Promise<ExpandedRecord[]> {
   if (!rows.length) return [];
 
@@ -127,7 +150,28 @@ export async function GET() {
       .all();
 
     const records = await expandRecords(rows as AirtableRecord[]);
-    return Response.json({ records });
+
+    const fieldOrderSet = new Set<string>();
+    const first = rows[0] as any;
+    const firstFields = (first?._rawJson?.fields as Record<string, any>) || (first?.fields as Record<string, any>) || {};
+    for (const key of Object.keys(firstFields)) fieldOrderSet.add(key);
+    for (const row of rows as AirtableRecord[]) {
+      const fields = (row.fields || {}) as Record<string, any>;
+      for (const key of Object.keys(fields)) fieldOrderSet.add(key);
+    }
+    const fieldOrder = Array.from(fieldOrderSet);
+
+    const displayNameMap: Record<string, string> = {};
+    for (const key of fieldOrder) {
+      const display = toDisplayLabel(key);
+      if (display) {
+        if (!displayNameMap[key]) displayNameMap[key] = display;
+        const normalized = normalizeFieldKey(key);
+        if (normalized && !displayNameMap[normalized]) displayNameMap[normalized] = display;
+      }
+    }
+
+    return Response.json({ records, fieldOrder, displayNameMap });
   } catch (e: any) {
     return new Response(JSON.stringify({ error: e?.message || "Failed" }), { status: 500 });
   }

--- a/apps/web/components/admin/ColumnManager.tsx
+++ b/apps/web/components/admin/ColumnManager.tsx
@@ -1,0 +1,255 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  useSortable,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import type { VisibilityRule } from "./types";
+
+export type ColumnLayout = {
+  order: string[];
+  hidden: string[];
+};
+
+export type ColumnDescriptor = {
+  normalizedId: string;
+  label: string;
+};
+
+type Props = {
+  tableId: string;
+  columns: ColumnDescriptor[];
+  layout: ColumnLayout;
+  onLayoutChange: (layout: ColumnLayout) => void;
+  rules: Record<string, VisibilityRule>;
+  onRuleChange: (
+    normalizedId: string,
+    visibility: { visibleToLP: boolean; visibleToPartners: boolean }
+  ) => Promise<void>;
+};
+
+type SortableItemProps = {
+  id: string;
+  children: React.ReactNode;
+};
+
+function SortableItem({ id, children }: SortableItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id });
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  } as React.CSSProperties;
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      className={`rounded-2xl border bg-white shadow-sm transition ${
+        isDragging ? "ring-2 ring-blue-200" : ""
+      }`}
+    >
+      <div className="flex items-start justify-between gap-3 p-3">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            className="cursor-grab rounded border bg-white px-2 py-1 text-xs text-slate-500 hover:bg-slate-50"
+            {...listeners}
+            {...attributes}
+          >
+            ≡
+          </button>
+          <div className="flex-1">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function ColumnManager({
+  tableId,
+  columns,
+  layout,
+  onLayoutChange,
+  rules,
+  onRuleChange,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [pendingRule, setPendingRule] = useState<string | null>(null);
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+
+  const columnMap = useMemo(() => {
+    const map = new Map<string, ColumnDescriptor>();
+    for (const col of columns) map.set(col.normalizedId, col);
+    return map;
+  }, [columns]);
+
+  const hiddenSet = useMemo(() => new Set(layout.hidden || []), [layout.hidden]);
+
+  const orderedIds = useMemo(() => layout.order.filter((id) => columnMap.has(id)), [layout.order, columnMap]);
+
+  useEffect(() => {
+    if (!open) setPendingRule(null);
+  }, [open]);
+
+  const toggleVisibility = (id: string) => {
+    const nextHidden = new Set(hiddenSet);
+    if (nextHidden.has(id)) nextHidden.delete(id);
+    else nextHidden.add(id);
+    onLayoutChange({ order: layout.order, hidden: Array.from(nextHidden) });
+  };
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    const { active, over } = event;
+    if (!active?.id || !over?.id || active.id === over.id) return;
+    const activeId = String(active.id);
+    const overId = String(over.id);
+    if (!layout.order.includes(activeId) || !layout.order.includes(overId)) return;
+    const nextOrder = arrayMove(layout.order, layout.order.indexOf(activeId), layout.order.indexOf(overId));
+    onLayoutChange({ order: nextOrder, hidden: layout.hidden });
+  };
+
+  const makeRuleKey = (normalizedId: string) => `${tableId}:${normalizedId}`;
+
+  const handleRuleToggle = async (normalizedId: string, which: "lp" | "partners", value: boolean) => {
+    const key = makeRuleKey(normalizedId);
+    const current = rules[key];
+    const nextVisibility = {
+      visibleToLP: which === "lp" ? value : current?.visibleToLP ?? true,
+      visibleToPartners: which === "partners" ? value : current?.visibleToPartners ?? true,
+    };
+    try {
+      setPendingRule(normalizedId);
+      await onRuleChange(normalizedId, nextVisibility);
+    } catch (e) {
+      console.error(e);
+      alert("Failed to update visibility rule. Please try again.");
+    } finally {
+      setPendingRule(null);
+    }
+  };
+
+  return (
+    <>
+      <button
+        type="button"
+        className="rounded-lg border bg-white px-3 py-2 text-sm font-medium shadow-sm hover:bg-blue-50"
+        onClick={() => setOpen(true)}
+      >
+        Columns
+      </button>
+
+      {open && (
+        <div className="fixed inset-0 z-40">
+          <div className="absolute inset-0 bg-black/30" onClick={() => setOpen(false)} />
+          <aside className="absolute right-0 top-0 flex h-full w-full max-w-xl flex-col bg-white shadow-2xl">
+            <header className="flex items-center justify-between border-b px-5 py-4">
+              <div>
+                <h2 className="text-base font-semibold text-slate-900">Manage Columns</h2>
+                <p className="text-sm text-slate-500">Arrange local columns and adjust LP/Partner visibility.</p>
+              </div>
+              <button
+                type="button"
+                className="rounded border px-3 py-1 text-sm"
+                onClick={() => setOpen(false)}
+              >
+                Close
+              </button>
+            </header>
+
+            <div className="flex flex-1 flex-col gap-4 overflow-hidden p-5">
+              <div className="grid flex-1 grid-cols-1 gap-4 overflow-hidden md:grid-cols-2">
+                <div className="flex flex-1 flex-col overflow-hidden">
+                  <h3 className="mb-2 text-sm font-semibold text-slate-700">Admin layout</h3>
+                  <div className="flex-1 space-y-3 overflow-auto pr-1">
+                    <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+                      <SortableContext items={orderedIds} strategy={verticalListSortingStrategy}>
+                        {orderedIds.map((id) => {
+                          const col = columnMap.get(id);
+                          if (!col) return null;
+                          return (
+                            <SortableItem id={id} key={id}>
+                              <label className="flex items-center gap-2 text-sm font-medium text-slate-800">
+                                <input
+                                  type="checkbox"
+                                  checked={!hiddenSet.has(id)}
+                                  onChange={() => toggleVisibility(id)}
+                                />
+                                {col.label}
+                              </label>
+                            </SortableItem>
+                          );
+                        })}
+                        {orderedIds.length === 0 && (
+                          <div className="rounded-2xl border border-dashed p-6 text-center text-sm text-slate-500">
+                            No fields available.
+                          </div>
+                        )}
+                      </SortableContext>
+                    </DndContext>
+                  </div>
+                </div>
+
+                <div className="flex flex-1 flex-col overflow-hidden">
+                  <h3 className="mb-2 text-sm font-semibold text-slate-700">LP / Partner visibility</h3>
+                  <div className="flex-1 space-y-3 overflow-auto pr-1">
+                    {orderedIds.map((id) => {
+                      const col = columnMap.get(id);
+                      if (!col) return null;
+                      const key = makeRuleKey(id);
+                      const rule = rules[key];
+                      const isSaving = pendingRule === id;
+                      return (
+                        <div key={id} className="rounded-2xl border bg-white p-3 shadow-sm">
+                          <div className="text-sm font-medium text-slate-800">{col.label}</div>
+                          <div className="mt-2 flex items-center gap-4 text-xs text-slate-600">
+                            <label className="inline-flex items-center gap-2">
+                              <input
+                                type="checkbox"
+                                checked={rule ? !!rule.visibleToLP : true}
+                                onChange={(e) => handleRuleToggle(id, "lp", e.target.checked)}
+                                disabled={isSaving}
+                              />
+                              <span>Visible to LPs</span>
+                            </label>
+                            <label className="inline-flex items-center gap-2">
+                              <input
+                                type="checkbox"
+                                checked={rule ? !!rule.visibleToPartners : true}
+                                onChange={(e) => handleRuleToggle(id, "partners", e.target.checked)}
+                                disabled={isSaving}
+                              />
+                              <span>Visible to Partners</span>
+                            </label>
+                            {isSaving && <span className="text-xs text-blue-500">Saving…</span>}
+                          </div>
+                        </div>
+                      );
+                    })}
+                    {orderedIds.length === 0 && (
+                      <div className="rounded-2xl border border-dashed p-6 text-center text-sm text-slate-500">
+                        No fields available.
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </aside>
+        </div>
+      )}
+    </>
+  );
+}
+

--- a/apps/web/components/admin/types.ts
+++ b/apps/web/components/admin/types.ts
@@ -1,0 +1,10 @@
+export type VisibilityRule = {
+  id?: string;
+  tableId: string;
+  fieldId: string;
+  normalizedFieldId?: string;
+  visibleToLP: boolean;
+  visibleToPartners: boolean;
+  notes?: string;
+};
+

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,7 +9,10 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
     "@tanstack/react-table": "^8.13.0",
+    "@tanstack/react-virtual": "^3.13.12",
     "airtable": "^0.11.6",
     "bottleneck": "^2.19.5",
     "next": "^14.2.32",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       airtable:
         specifier: ^0.11.6
         version: 0.11.6
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
       dotenv:
         specifier: ^16.4.5
         version: 16.6.1
@@ -27,12 +30,27 @@ importers:
 
   apps/web:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
       '@tanstack/react-table':
         specifier: ^8.13.0
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.12
+        version: 3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      airtable:
+        specifier: ^0.11.6
+        version: 0.11.6
+      bottleneck:
+        specifier: ^2.19.5
+        version: 2.19.5
       next:
-        specifier: 14.2.4
-        version: 14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: ^14.2.32
+        version: 14.2.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -68,6 +86,28 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -85,59 +125,59 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
-  '@next/env@14.2.4':
-    resolution: {integrity: sha512-3EtkY5VDkuV2+lNmKlbkibIJxcO4oIHEhBWne6PaAp+76J9KoSsGvNikp6ivzAT8dhhBMYrm6op2pS1ApG0Hzg==}
+  '@next/env@14.2.32':
+    resolution: {integrity: sha512-n9mQdigI6iZ/DF6pCTwMKeWgF2e8lg7qgt5M7HXMLtyhZYMnf/u905M18sSpPmHL9MKp9JHo56C6jrD2EvWxng==}
 
-  '@next/swc-darwin-arm64@14.2.4':
-    resolution: {integrity: sha512-AH3mO4JlFUqsYcwFUHb1wAKlebHU/Hv2u2kb1pAuRanDZ7pD/A/KPD98RHZmwsJpdHQwfEc/06mgpSzwrJYnNg==}
+  '@next/swc-darwin-arm64@14.2.32':
+    resolution: {integrity: sha512-osHXveM70zC+ilfuFa/2W6a1XQxJTvEhzEycnjUaVE8kpUS09lDpiDDX2YLdyFCzoUbvbo5r0X1Kp4MllIOShw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@14.2.4':
-    resolution: {integrity: sha512-QVadW73sWIO6E2VroyUjuAxhWLZWEpiFqHdZdoQ/AMpN9YWGuHV8t2rChr0ahy+irKX5mlDU7OY68k3n4tAZTg==}
+  '@next/swc-darwin-x64@14.2.32':
+    resolution: {integrity: sha512-P9NpCAJuOiaHHpqtrCNncjqtSBi1f6QUdHK/+dNabBIXB2RUFWL19TY1Hkhu74OvyNQEYEzzMJCMQk5agjw1Qg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@14.2.4':
-    resolution: {integrity: sha512-KT6GUrb3oyCfcfJ+WliXuJnD6pCpZiosx2X3k66HLR+DMoilRb76LpWPGb4tZprawTtcnyrv75ElD6VncVamUQ==}
+  '@next/swc-linux-arm64-gnu@14.2.32':
+    resolution: {integrity: sha512-v7JaO0oXXt6d+cFjrrKqYnR2ubrD+JYP7nQVRZgeo5uNE5hkCpWnHmXm9vy3g6foMO8SPwL0P3MPw1c+BjbAzA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@14.2.4':
-    resolution: {integrity: sha512-Alv8/XGSs/ytwQcbCHwze1HmiIkIVhDHYLjczSVrf0Wi2MvKn/blt7+S6FJitj3yTlMwMxII1gIJ9WepI4aZ/A==}
+  '@next/swc-linux-arm64-musl@14.2.32':
+    resolution: {integrity: sha512-tA6sIKShXtSJBTH88i0DRd6I9n3ZTirmwpwAqH5zdJoQF7/wlJXR8DkPmKwYl5mFWhEKr5IIa3LfpMW9RRwKmQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@14.2.4':
-    resolution: {integrity: sha512-ze0ShQDBPCqxLImzw4sCdfnB3lRmN3qGMB2GWDRlq5Wqy4G36pxtNOo2usu/Nm9+V2Rh/QQnrRc2l94kYFXO6Q==}
+  '@next/swc-linux-x64-gnu@14.2.32':
+    resolution: {integrity: sha512-7S1GY4TdnlGVIdeXXKQdDkfDysoIVFMD0lJuVVMeb3eoVjrknQ0JNN7wFlhCvea0hEk0Sd4D1hedVChDKfV2jw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@14.2.4':
-    resolution: {integrity: sha512-8dwC0UJoc6fC7PX70csdaznVMNr16hQrTDAMPvLPloazlcaWfdPogq+UpZX6Drqb1OBlwowz8iG7WR0Tzk/diQ==}
+  '@next/swc-linux-x64-musl@14.2.32':
+    resolution: {integrity: sha512-OHHC81P4tirVa6Awk6eCQ6RBfWl8HpFsZtfEkMpJ5GjPsJ3nhPe6wKAJUZ/piC8sszUkAgv3fLflgzPStIwfWg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@14.2.4':
-    resolution: {integrity: sha512-jxyg67NbEWkDyvM+O8UDbPAyYRZqGLQDTPwvrBBeOSyVWW/jFQkQKQ70JDqDSYg1ZDdl+E3nkbFbq8xM8E9x8A==}
+  '@next/swc-win32-arm64-msvc@14.2.32':
+    resolution: {integrity: sha512-rORQjXsAFeX6TLYJrCG5yoIDj+NKq31Rqwn8Wpn/bkPNy5rTHvOXkW8mLFonItS7QC6M+1JIIcLe+vOCTOYpvg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-ia32-msvc@14.2.4':
-    resolution: {integrity: sha512-twrmN753hjXRdcrZmZttb/m5xaCBFa48Dt3FbeEItpJArxriYDunWxJn+QFXdJ3hPkm4u7CKxncVvnmgQMY1ag==}
+  '@next/swc-win32-ia32-msvc@14.2.32':
+    resolution: {integrity: sha512-jHUeDPVHrgFltqoAqDB6g6OStNnFxnc7Aks3p0KE0FbwAvRg6qWKYF5mSTdCTxA3axoSAUwxYdILzXJfUwlHhA==}
     engines: {node: '>= 10'}
     cpu: [ia32]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@14.2.4':
-    resolution: {integrity: sha512-tkLrjBzqFTP8DVrAAQmZelEahfR9OxWpFR++vAI9FBhCiIxtwHwBHC23SBHCTURBtwB4kc/x44imVOnkKGNVGg==}
+  '@next/swc-win32-x64-msvc@14.2.32':
+    resolution: {integrity: sha512-2N0lSoU4GjfLSO50wvKpMQgKd4HdI2UHEhQPPPnlgfBJlOgJxkjpkYBqzk08f1gItBB6xF/n+ykso2hgxuydsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -171,9 +211,18 @@ packages:
       react: '>=16.8'
       react-dom: '>=16.8'
 
+  '@tanstack/react-virtual@3.13.12':
+    resolution: {integrity: sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/table-core@8.21.3':
     resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
     engines: {node: '>=12'}
+
+  '@tanstack/virtual-core@3.13.12':
+    resolution: {integrity: sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==}
 
   '@types/node@14.18.63':
     resolution: {integrity: sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==}
@@ -258,6 +307,9 @@ packages:
     resolution: {integrity: sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
+  bottleneck@2.19.5:
+    resolution: {integrity: sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw==}
+
   brace-expansion@1.1.12:
     resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
@@ -331,6 +383,10 @@ packages:
   cookie@0.7.1:
     resolution: {integrity: sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==}
     engines: {node: '>= 0.6'}
+
+  cors@2.8.5:
+    resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -651,8 +707,8 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
-  next@14.2.4:
-    resolution: {integrity: sha512-R8/V7vugY+822rsQGQCjoLhMuC9oFj9SOi4Cl4b2wjDrseD0LRZ10W7R6Czo4w9ZznVSshKjuIomsRjvm9EKJQ==}
+  next@14.2.32:
+    resolution: {integrity: sha512-fg5g0GZ7/nFc09X8wLe6pNSU8cLWbLRG3TZzPJ1BJvi2s9m7eF991se67wliM9kR5yLHRkyGKU49MMx58s3LJg==}
     engines: {node: '>=18.17.0'}
     hasBin: true
     peerDependencies:
@@ -1061,6 +1117,31 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
+  '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@dnd-kit/utilities': 3.2.2(react@18.3.1)
+      react: 18.3.1
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+      tslib: 2.8.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -1084,33 +1165,33 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@next/env@14.2.4': {}
+  '@next/env@14.2.32': {}
 
-  '@next/swc-darwin-arm64@14.2.4':
+  '@next/swc-darwin-arm64@14.2.32':
     optional: true
 
-  '@next/swc-darwin-x64@14.2.4':
+  '@next/swc-darwin-x64@14.2.32':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@14.2.4':
+  '@next/swc-linux-arm64-gnu@14.2.32':
     optional: true
 
-  '@next/swc-linux-arm64-musl@14.2.4':
+  '@next/swc-linux-arm64-musl@14.2.32':
     optional: true
 
-  '@next/swc-linux-x64-gnu@14.2.4':
+  '@next/swc-linux-x64-gnu@14.2.32':
     optional: true
 
-  '@next/swc-linux-x64-musl@14.2.4':
+  '@next/swc-linux-x64-musl@14.2.32':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@14.2.4':
+  '@next/swc-win32-arm64-msvc@14.2.32':
     optional: true
 
-  '@next/swc-win32-ia32-msvc@14.2.4':
+  '@next/swc-win32-ia32-msvc@14.2.32':
     optional: true
 
-  '@next/swc-win32-x64-msvc@14.2.4':
+  '@next/swc-win32-x64-msvc@14.2.32':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -1141,7 +1222,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
+  '@tanstack/react-virtual@3.13.12(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@tanstack/virtual-core': 3.13.12
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   '@tanstack/table-core@8.21.3': {}
+
+  '@tanstack/virtual-core@3.13.12': {}
 
   '@types/node@14.18.63': {}
 
@@ -1235,6 +1324,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  bottleneck@2.19.5: {}
+
   brace-expansion@1.1.12:
     dependencies:
       balanced-match: 1.0.2
@@ -1309,6 +1400,11 @@ snapshots:
   cookie-signature@1.0.6: {}
 
   cookie@0.7.1: {}
+
+  cors@2.8.5:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -1610,9 +1706,9 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  next@14.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next@14.2.32(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      '@next/env': 14.2.4
+      '@next/env': 14.2.32
       '@swc/helpers': 0.5.5
       busboy: 1.6.0
       caniuse-lite: 1.0.30001741
@@ -1622,15 +1718,15 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-jsx: 5.1.1(react@18.3.1)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 14.2.4
-      '@next/swc-darwin-x64': 14.2.4
-      '@next/swc-linux-arm64-gnu': 14.2.4
-      '@next/swc-linux-arm64-musl': 14.2.4
-      '@next/swc-linux-x64-gnu': 14.2.4
-      '@next/swc-linux-x64-musl': 14.2.4
-      '@next/swc-win32-arm64-msvc': 14.2.4
-      '@next/swc-win32-ia32-msvc': 14.2.4
-      '@next/swc-win32-x64-msvc': 14.2.4
+      '@next/swc-darwin-arm64': 14.2.32
+      '@next/swc-darwin-x64': 14.2.32
+      '@next/swc-linux-arm64-gnu': 14.2.32
+      '@next/swc-linux-arm64-musl': 14.2.32
+      '@next/swc-linux-x64-gnu': 14.2.32
+      '@next/swc-linux-x64-musl': 14.2.32
+      '@next/swc-win32-arm64-msvc': 14.2.32
+      '@next/swc-win32-ia32-msvc': 14.2.32
+      '@next/swc-win32-x64-msvc': 14.2.32
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros


### PR DESCRIPTION
## Summary
- return the full Partner Investments schema from the data API, including display name metadata for case-insensitive fields
- rebuild the admin table to derive columns dynamically, persist local layouts, respect visibility rules when impersonating, and add CSV export + virtualization
- introduce a Column Manager drawer with drag-and-drop ordering, local toggles, and LP/Partner visibility controls, plus add required dependencies

## Testing
- `pnpm --filter web lint` *(fails: requires interactive ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68c9c38f6394832080732cdb775e058d