### PR TITLE
Add NextAuth authentication and LP dashboard experience

### DIFF
--- a/apps/web/app/api/auth/[...nextauth]/route.ts
+++ b/apps/web/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,68 @@
+import NextAuth, { type NextAuthOptions } from "next-auth";
+import EmailProvider from "next-auth/providers/email";
+import GoogleProvider from "next-auth/providers/google";
+
+function isAdmin(email?: string | null): boolean {
+  if (!email) return false;
+  const raw = process.env.ADMIN_EMAILS || "";
+  const list = raw
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  return list.includes(email.toLowerCase());
+}
+
+const providers: NextAuthOptions["providers"] = [];
+
+if (process.env.EMAIL_SERVER && process.env.EMAIL_FROM) {
+  providers.push(
+    EmailProvider({
+      server: process.env.EMAIL_SERVER,
+      from: process.env.EMAIL_FROM,
+    })
+  );
+}
+
+if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
+  providers.push(
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    })
+  );
+}
+
+if (providers.length === 0) {
+  throw new Error("No authentication providers configured");
+}
+
+export const authOptions: NextAuthOptions = {
+  providers,
+  pages: {
+    signIn: "/auth/signin",
+  },
+  session: {
+    strategy: "jwt",
+  },
+  callbacks: {
+    async jwt({ token, user }) {
+      const email = (user?.email as string | undefined) ?? (token.email as string | undefined);
+      if (email) {
+        token.email = email;
+      }
+      token.role = isAdmin(email) ? "admin" : "lp";
+      return token;
+    },
+    async session({ session, token }) {
+      if (session.user) {
+        session.user.role = (token.role as string | undefined) ?? (isAdmin(session.user.email) ? "admin" : "lp");
+      }
+      return session;
+    },
+  },
+};
+
+const handler = NextAuth(authOptions);
+
+export { handler as GET, handler as POST };
+export { authOptions };

--- a/apps/web/app/api/lp/data/route.ts
+++ b/apps/web/app/api/lp/data/route.ts
@@ -1,0 +1,135 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import type Airtable from "airtable";
+import {
+  expandPartnerInvestmentRecords,
+  fetchVisibilityRules,
+  selectPartnerInvestmentsByEmail,
+  type ExpandedRecord,
+} from "@/lib/airtablePartnerInvestments";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+
+const ESSENTIAL_FIELDS = [
+  "Partner Investment",
+  "Investment",
+  "Name",
+  "Fund",
+  "PRIMARY CONTACT",
+  "Primary Contact",
+  "Period Ending",
+  "Status",
+  "Status (I)",
+  "Commitment",
+  "Total NAV",
+  "Current NAV",
+  "Distributions",
+  "Net MOIC",
+];
+
+function toNumber(value: any): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.-]/g, "");
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function buildAllowedFields(role: string | undefined, rules: Airtable.Record<any>[]) {
+  if (role === "admin" || !rules.length) return null;
+  const allowed = new Set<string>();
+  for (const rule of rules) {
+    const fields = rule.fields as Record<string, any>;
+    const fieldId = fields?.fieldId as string | undefined;
+    const visibleToLP = Boolean(fields?.visibleToLP);
+    if (fieldId && visibleToLP) {
+      allowed.add(fieldId);
+    }
+  }
+  for (const field of ESSENTIAL_FIELDS) {
+    allowed.add(field);
+  }
+  return allowed;
+}
+
+function filterRecordFields(record: ExpandedRecord, allowed: Set<string> | null) {
+  if (!allowed) return record.fields;
+  const filtered: Record<string, any> = {};
+  for (const [key, value] of Object.entries(record.fields)) {
+    if (allowed.has(key)) {
+      filtered[key] = value;
+    }
+  }
+  return filtered;
+}
+
+function computeMetrics(records: Array<{ fields: Record<string, any> }>) {
+  let commitmentTotal = 0;
+  let navTotal = 0;
+  let distributionsTotal = 0;
+  let netMoicSum = 0;
+  let netMoicCount = 0;
+
+  for (const record of records) {
+    const fields = record.fields || {};
+
+    const commitment = toNumber(fields["Commitment"]);
+    if (commitment !== null) commitmentTotal += commitment;
+
+    const nav =
+      toNumber(fields["Total NAV"]) ??
+      toNumber(fields["Current NAV"]);
+    if (nav !== null) navTotal += nav;
+
+    const distributions = toNumber(fields["Distributions"]);
+    if (distributions !== null) distributionsTotal += distributions;
+
+    const netMoic = toNumber(fields["Net MOIC"]);
+    if (netMoic !== null) {
+      netMoicSum += netMoic;
+      netMoicCount += 1;
+    }
+  }
+
+  const netMoicAvg = netMoicCount > 0 ? netMoicSum / netMoicCount : 0;
+
+  return {
+    commitmentTotal,
+    navTotal,
+    distributionsTotal,
+    netMoicAvg,
+  };
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const email = session.user.email;
+  const role = session.user.role ?? "lp";
+
+  const [{ rows }, visibilityRules] = await Promise.all([
+    selectPartnerInvestmentsByEmail(email),
+    fetchVisibilityRules(),
+  ]);
+
+  const expanded = await expandPartnerInvestmentRecords(rows);
+  const allowedSet = buildAllowedFields(role, visibilityRules as Airtable.Record<any>[]);
+
+  const filteredRecords = expanded.map((record) => ({
+    id: record.id,
+    fields: filterRecordFields(record, allowedSet),
+    _updatedTime: record._updatedTime,
+  }));
+
+  const metrics = computeMetrics(filteredRecords);
+
+  return NextResponse.json({
+    records: filteredRecords,
+    metrics,
+  });
+}

--- a/apps/web/app/api/lp/documents/route.ts
+++ b/apps/web/app/api/lp/documents/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import {
+  expandPartnerInvestmentRecords,
+  selectPartnerInvestmentsByEmail,
+} from "@/lib/airtablePartnerInvestments";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+
+const ATTACHMENT_FIELD_HINTS = new Set([
+  "Latest PCAP File",
+  "PCAP Distribution Report",
+  "Subscription Doc",
+  "Subscription Document",
+  "Capital Call Notice",
+]);
+
+function extractAttachments(record: { id: string; fields: Record<string, any> }) {
+  const fields = record.fields || {};
+  const investmentName =
+    fields["Partner Investment"] ||
+    fields["Investment"] ||
+    fields["Name"] ||
+    "Investment";
+  const periodEnding = fields["Period Ending"] || null;
+
+  const documents: Array<{
+    name: string;
+    url: string;
+    size?: number;
+    type?: string;
+    investmentId: string;
+    investmentName: string;
+    periodEnding: string | null;
+  }> = [];
+
+  for (const [fieldName, value] of Object.entries(fields)) {
+    if (!Array.isArray(value) || value.length === 0) continue;
+    const looksLikeAttachment =
+      ATTACHMENT_FIELD_HINTS.has(fieldName) ||
+      value.some((item) => item && typeof item === "object" && "url" in item && typeof item.url === "string");
+    if (!looksLikeAttachment) continue;
+
+    for (const item of value) {
+      if (!item || typeof item !== "object" || typeof item.url !== "string") continue;
+      const name = (item as any).filename || (item as any).name || (item as any).title || fieldName;
+      documents.push({
+        name,
+        url: item.url,
+        size: (item as any).size,
+        type: (item as any).type,
+        investmentId: record.id,
+        investmentName,
+        periodEnding,
+      });
+    }
+  }
+
+  return documents;
+}
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { rows } = await selectPartnerInvestmentsByEmail(session.user.email);
+  const expanded = await expandPartnerInvestmentRecords(rows);
+
+  const documents = expanded.flatMap((record) => extractAttachments(record));
+
+  return NextResponse.json({ documents });
+}

--- a/apps/web/app/api/me/route.ts
+++ b/apps/web/app/api/me/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+
+export async function GET() {
+  const session = await getServerSession(authOptions);
+  if (!session || !session.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  return NextResponse.json({
+    email: session.user.email,
+    role: session.user.role ?? "lp",
+  });
+}

--- a/apps/web/app/auth/signin/page.tsx
+++ b/apps/web/app/auth/signin/page.tsx
@@ -1,0 +1,148 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { getProviders, signIn } from "next-auth/react";
+import type { ClientSafeProvider } from "next-auth/react";
+
+export default function SignInPage() {
+  const [providers, setProviders] = useState<Record<string, ClientSafeProvider> | null>(null);
+  const [email, setEmail] = useState("");
+  const [emailStatus, setEmailStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    getProviders().then((res) => {
+      if (isMounted) setProviders(res);
+    });
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const googleProvider = providers?.google;
+  const emailProvider = providers?.email;
+
+  async function handleEmailSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!emailProvider) return;
+    if (!email) {
+      setError("Please enter your email address");
+      return;
+    }
+    setError(null);
+    setEmailStatus("sending");
+    const result = await signIn("email", {
+      email,
+      redirect: false,
+      callbackUrl: "/lp",
+    });
+    if (result?.error) {
+      setEmailStatus("error");
+      setError("Unable to send sign-in link. Please try again.");
+    } else {
+      setEmailStatus("sent");
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center py-16 px-4">
+      <div className="w-full max-w-lg rounded-3xl bg-white shadow-xl border border-slate-200 p-10 space-y-8">
+        <div className="space-y-2 text-center">
+          <p className="text-sm font-semibold uppercase tracking-wide text-blue-600">JBV Investment Platform</p>
+          <h1 className="text-3xl font-semibold text-slate-900">Sign in to continue</h1>
+          <p className="text-sm text-slate-500">
+            Access your investments, documents, and insights from anywhere.
+          </p>
+        </div>
+
+        {error ? (
+          <div className="rounded-md bg-red-50 px-4 py-3 text-sm text-red-600 border border-red-200">
+            {error}
+          </div>
+        ) : null}
+
+        <div className="space-y-4">
+          {googleProvider ? (
+            <button
+              type="button"
+              onClick={() => signIn(googleProvider.id, { callbackUrl: "/lp" })}
+              className="w-full inline-flex items-center justify-center gap-2 rounded-xl border border-slate-200 bg-white py-3 text-sm font-medium text-slate-700 shadow-sm transition hover:border-blue-400 hover:text-blue-700"
+            >
+              <svg
+                className="h-5 w-5"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path
+                  fill="#4285F4"
+                  d="M23.52 12.273c0-.851-.076-1.67-.218-2.455H12v4.648h6.44a5.504 5.504 0 0 1-2.39 3.61v3.003h3.867c2.266-2.087 3.603-5.165 3.603-8.806z"
+                />
+                <path
+                  fill="#34A853"
+                  d="M12 24c3.24 0 5.956-1.074 7.941-2.92l-3.867-3.003c-1.075.72-2.449 1.146-4.074 1.146-3.132 0-5.787-2.116-6.737-4.96H1.243v3.118A12.001 12.001 0 0 0 12 24z"
+                />
+                <path
+                  fill="#FBBC05"
+                  d="M5.263 14.263A7.198 7.198 0 0 1 4.87 12c0-.785.135-1.545.377-2.263V6.62H1.243A11.998 11.998 0 0 0 0 12c0 1.933.46 3.759 1.243 5.38l4.02-3.117z"
+                />
+                <path
+                  fill="#EA4335"
+                  d="M12 4.75c1.76 0 3.337.605 4.583 1.795l3.437-3.438C17.951 1.232 15.235 0 12 0 7.32 0 3.258 2.69 1.243 6.62l4.004 3.117C6.213 6.866 8.868 4.75 12 4.75z"
+                />
+              </svg>
+              Sign in with Google
+            </button>
+          ) : null}
+
+          {emailProvider ? (
+            <div className="space-y-3">
+              <div className="flex items-center gap-3">
+                <div className="h-px flex-1 bg-slate-200" />
+                <span className="text-xs font-medium uppercase tracking-widest text-slate-400">or</span>
+                <div className="h-px flex-1 bg-slate-200" />
+              </div>
+              <form onSubmit={handleEmailSubmit} className="space-y-4">
+                <label className="block text-left text-sm font-medium text-slate-600">
+                  Email address
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(event) => {
+                      setEmail(event.target.value);
+                      setEmailStatus("idle");
+                    }}
+                    className="mt-1 w-full rounded-xl border border-slate-200 px-4 py-3 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                    placeholder="you@example.com"
+                    required
+                  />
+                </label>
+                <button
+                  type="submit"
+                  className="w-full rounded-xl bg-blue-600 px-4 py-3 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                  disabled={emailStatus === "sending"}
+                >
+                  {emailStatus === "sending" ? "Sending magic link…" : "Send magic link"}
+                </button>
+                {emailStatus === "sent" ? (
+                  <p className="text-sm text-blue-600">Check your inbox for a secure sign-in link.</p>
+                ) : null}
+              </form>
+            </div>
+          ) : null}
+
+          {!googleProvider && !emailProvider ? (
+            <p className="text-sm text-slate-500 text-center">
+              No authentication providers are currently configured. Please contact your administrator.
+            </p>
+          ) : null}
+        </div>
+
+        <p className="text-xs text-slate-400 text-center">
+          By signing in you agree to our confidentiality and data use policies.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/lp/NavTabs.tsx
+++ b/apps/web/app/lp/NavTabs.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const NAV_ITEMS = [
+  { href: "/lp", label: "Overview" },
+  { href: "/lp/investments", label: "Investments" },
+  { href: "/lp/docs", label: "Documents" },
+  { href: "/lp/help", label: "Help" },
+];
+
+export default function NavTabs() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex flex-wrap items-center gap-2 text-sm font-medium text-slate-600">
+      {NAV_ITEMS.map((item) => {
+        const isActive =
+          pathname === item.href ||
+          (item.href !== "/lp" && pathname.startsWith(`${item.href}/`));
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`rounded-full px-4 py-2 transition ${
+              isActive
+                ? "bg-blue-600 text-white shadow"
+                : "hover:bg-blue-50 hover:text-blue-700"
+            }`}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/apps/web/app/lp/components/RefreshStatus.tsx
+++ b/apps/web/app/lp/components/RefreshStatus.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import type { PollingStatus } from "@/hooks/usePollingResource";
+
+const LABELS: Record<PollingStatus, string> = {
+  idle: "Idle",
+  refreshing: "Refreshing",
+  error: "Error",
+};
+
+export function RefreshStatus({ status }: { status: PollingStatus }) {
+  const color =
+    status === "refreshing"
+      ? "bg-blue-100 text-blue-700"
+      : status === "error"
+      ? "bg-red-100 text-red-700"
+      : "bg-slate-100 text-slate-600";
+
+  return (
+    <span className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-xs font-medium ${color}`}>
+      <span className="h-2 w-2 rounded-full bg-current" />
+      Refresh: {LABELS[status]}
+    </span>
+  );
+}

--- a/apps/web/app/lp/docs/page.tsx
+++ b/apps/web/app/lp/docs/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useMemo } from "react";
+import { RefreshStatus } from "../components/RefreshStatus";
+import { usePollingResource } from "@/hooks/usePollingResource";
+import { formatDate } from "@/lib/format";
+
+interface DocumentItem {
+  name: string;
+  url: string;
+  size?: number;
+  type?: string;
+  investmentId: string;
+  investmentName: string;
+  periodEnding: string | null;
+}
+
+interface DocumentsResponse {
+  documents: DocumentItem[];
+}
+
+export default function DocumentsPage() {
+  const { data, status, error, hasLoaded } = usePollingResource<DocumentsResponse>("/api/lp/documents");
+
+  const groupedDocuments = useMemo(() => {
+    const map = new Map<string, DocumentItem[]>();
+    (data?.documents ?? []).forEach((doc) => {
+      const key = doc.investmentName || "General";
+      if (!map.has(key)) map.set(key, []);
+      map.get(key)!.push(doc);
+    });
+    return Array.from(map.entries()).map(([investmentName, docs]) => ({ investmentName, docs }));
+  }, [data?.documents]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900">Documents</h2>
+          <p className="text-sm text-slate-500">
+            PCAP statements, subscription documents, and capital call notices filtered for your account.
+          </p>
+        </div>
+        <RefreshStatus status={error ? "error" : status} />
+      </div>
+
+      {hasLoaded ? (
+        groupedDocuments.length ? (
+          <div className="space-y-6">
+            {groupedDocuments.map(({ investmentName, docs }) => (
+              <section key={investmentName} className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+                <h3 className="text-lg font-semibold text-slate-900">{investmentName}</h3>
+                <div className="mt-4 space-y-3">
+                  {docs.map((doc) => (
+                    <div
+                      key={`${doc.investmentId}-${doc.name}-${doc.url}`}
+                      className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3"
+                    >
+                      <div>
+                        <p className="font-medium text-slate-900">{doc.name}</p>
+                        <p className="text-xs text-slate-500">
+                          {doc.periodEnding ? `Period ending ${formatDate(doc.periodEnding)}` : "Most recent"}
+                          {doc.size ? ` • ${(doc.size / (1024 * 1024)).toFixed(2)} MB` : ""}
+                        </p>
+                      </div>
+                      <a
+                        href={doc.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-xs font-semibold text-white hover:bg-blue-700"
+                      >
+                        Download
+                      </a>
+                    </div>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        ) : (
+          <div className="rounded-3xl border border-slate-200 bg-slate-50 p-10 text-center text-sm text-slate-500">
+            No documents are available yet. Check back soon for new uploads.
+          </div>
+        )
+      ) : (
+        <div className="h-48 animate-pulse rounded-3xl bg-slate-100" />
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/lp/help/page.tsx
+++ b/apps/web/app/lp/help/page.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+export default function HelpPage() {
+  return (
+    <div className="rounded-3xl border border-slate-200 bg-white p-8 shadow-sm">
+      <h2 className="text-xl font-semibold text-slate-900">Need assistance?</h2>
+      <p className="mt-3 text-sm text-slate-600">
+        For support with the JBV Investment Platform, please contact <a href="mailto:support@jbv.com" className="text-blue-600 hover:underline">support@jbv.com</a> or reach out to your relationship manager.
+      </p>
+      <ul className="mt-6 space-y-3 text-sm text-slate-600">
+        <li>
+          <span className="font-semibold text-slate-800">Account Access:</span> Request new user access or report sign-in issues.
+        </li>
+        <li>
+          <span className="font-semibold text-slate-800">Documents:</span> Let us know if a distribution notice or subscription file is missing.
+        </li>
+        <li>
+          <span className="font-semibold text-slate-800">Data Questions:</span> We can help reconcile commitment balances, NAV values, or performance metrics.
+        </li>
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/app/lp/investments/[id]/page.tsx
+++ b/apps/web/app/lp/investments/[id]/page.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import { useMemo } from "react";
+import { useParams } from "next/navigation";
+import {
+  LineChart,
+  Line,
+  CartesianGrid,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+} from "recharts";
+import Link from "next/link";
+import { RefreshStatus } from "../../components/RefreshStatus";
+import { usePollingResource } from "@/hooks/usePollingResource";
+import { formatCurrencyUSD, formatNumber, formatDate } from "@/lib/format";
+
+interface LpRecord {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime: string | null;
+}
+
+interface MetricsResponse {
+  records: LpRecord[];
+}
+
+interface DocumentItem {
+  name: string;
+  url: string;
+  size?: number;
+  type?: string;
+  investmentId: string;
+  investmentName: string;
+  periodEnding: string | null;
+}
+
+interface DocumentsResponse {
+  documents: DocumentItem[];
+}
+
+const CURRENCY_HINTS = [
+  "commitment",
+  "capital",
+  "nav",
+  "distribution",
+  "cost",
+  "value",
+];
+const PERCENT_HINTS = ["percent", "%", "irr", "moic", "multiple"];
+const DATE_HINTS = ["date", "period", "closing", "updated"];
+
+function coerceNumber(value: any): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.-]/g, "");
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function valueToText(value: any): string {
+  if (value === null || value === undefined) return "";
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (item && typeof item === "object") {
+          if ("displayName" in item) return String(item.displayName ?? "");
+          if ("filename" in item) return String((item as any).filename ?? (item as any).name ?? "");
+          if ("name" in item) return String((item as any).name ?? "");
+        }
+        return String(item ?? "");
+      })
+      .filter(Boolean)
+      .join("; ");
+  }
+  if (typeof value === "object") {
+    if ("displayName" in value) return String((value as any).displayName ?? "");
+    if ("name" in value) return String((value as any).name ?? "");
+  }
+  return String(value ?? "");
+}
+
+function formatFieldValue(key: string, value: any) {
+  if (value === null || value === undefined || value === "") return "—";
+  const normalized = key.toLowerCase();
+
+  if (Array.isArray(value)) {
+    if (!value.length) return "—";
+    if (value[0] && typeof value[0] === "object" && "url" in value[0]) {
+      return (
+        <div className="flex flex-wrap gap-2">
+          {value.map((item: any, idx: number) => (
+            <a
+              key={`${key}-${idx}`}
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center rounded-full border border-blue-200 px-3 py-1 text-xs text-blue-700 hover:bg-blue-50"
+            >
+              {(item.filename || item.name || "Document") as string}
+            </a>
+          ))}
+        </div>
+      );
+    }
+    return (
+      <div className="flex flex-wrap gap-2">
+        {value.map((item: any, idx: number) => (
+          <span key={`${key}-chip-${idx}`} className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-700">
+            {valueToText(item) || "—"}
+          </span>
+        ))}
+      </div>
+    );
+  }
+
+  if (typeof value === "number") {
+    if (CURRENCY_HINTS.some((hint) => normalized.includes(hint))) return formatCurrencyUSD(value);
+    if (PERCENT_HINTS.some((hint) => normalized.includes(hint))) return formatPercent(value);
+    return formatNumber(value);
+  }
+
+  if (typeof value === "string") {
+    if (DATE_HINTS.some((hint) => normalized.includes(hint))) return formatDate(value);
+    const numeric = coerceNumber(value);
+    if (numeric !== null && CURRENCY_HINTS.some((hint) => normalized.includes(hint))) return formatCurrencyUSD(numeric);
+    if (numeric !== null && PERCENT_HINTS.some((hint) => normalized.includes(hint))) return formatPercent(numeric);
+    return value;
+  }
+
+  return valueToText(value) || "—";
+}
+
+export default function InvestmentDetailPage() {
+  const params = useParams<{ id: string }>();
+  const investmentId = Array.isArray(params?.id) ? params.id[0] : params?.id;
+  const {
+    data: investmentData,
+    status,
+    error,
+    hasLoaded,
+  } = usePollingResource<MetricsResponse>("/api/lp/data");
+  const {
+    data: documentData,
+    status: docStatus,
+    error: docError,
+    hasLoaded: docsLoaded,
+  } = usePollingResource<DocumentsResponse>("/api/lp/documents");
+
+  const currentRecord = useMemo(() => {
+    return investmentData?.records.find((record) => record.id === investmentId) ?? null;
+  }, [investmentData?.records, investmentId]);
+
+  const investmentName = useMemo(() => {
+    if (!currentRecord) return "Investment";
+    return (
+      valueToText(
+        currentRecord.fields["Partner Investment"] ??
+          currentRecord.fields["Investment"] ??
+          currentRecord.fields["Name"] ??
+          ""
+      ) || "Investment"
+    );
+  }, [currentRecord]);
+
+  const relatedRecords = useMemo(() => {
+    if (!currentRecord) return [] as LpRecord[];
+    const identifier = valueToText(
+      currentRecord.fields["Partner Investment"] ??
+        currentRecord.fields["Investment"] ??
+        currentRecord.fields["Name"] ??
+        ""
+    );
+    if (!identifier) return [currentRecord];
+    return (investmentData?.records ?? []).filter((record) => {
+      const name = valueToText(
+        record.fields["Partner Investment"] ??
+          record.fields["Investment"] ??
+          record.fields["Name"] ??
+          ""
+      );
+      return name === identifier;
+    });
+  }, [currentRecord, investmentData?.records]);
+
+  const timelineData = useMemo(() => {
+    return relatedRecords
+      .map((record) => {
+        const fields = record.fields || {};
+        const period = fields["Period Ending"] as string | undefined;
+        const date = period ? new Date(period) : record._updatedTime ? new Date(record._updatedTime) : null;
+        const sortValue = date && !Number.isNaN(date.getTime()) ? date.getTime() : Date.now();
+        const label = date && !Number.isNaN(date.getTime()) ? date.toLocaleDateString() : period ?? "Undated";
+        const navValue =
+          coerceNumber(fields["Total NAV"]) ??
+          coerceNumber(fields["Current NAV"]);
+        return navValue !== null
+          ? {
+              label,
+              value: navValue,
+              sortValue,
+            }
+          : null;
+      })
+      .filter((entry): entry is { label: string; value: number; sortValue: number } => Boolean(entry))
+      .sort((a, b) => a.sortValue - b.sortValue);
+  }, [relatedRecords]);
+
+  const documents = useMemo(() => {
+    if (!investmentId) return [];
+    return (documentData?.documents ?? []).filter((doc) => doc.investmentId === investmentId);
+  }, [documentData?.documents, investmentId]);
+
+  const commitment = coerceNumber(currentRecord?.fields["Commitment"]);
+  const nav =
+    coerceNumber(currentRecord?.fields["Total NAV"]) ??
+    coerceNumber(currentRecord?.fields["Current NAV"]);
+  const distributions = coerceNumber(currentRecord?.fields["Distributions"]);
+  const netMoic = coerceNumber(currentRecord?.fields["Net MOIC"]);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <Link href="/lp/investments" className="text-xs font-medium text-blue-600 hover:underline">
+            ← Back to investments
+          </Link>
+          <h2 className="mt-2 text-2xl font-semibold text-slate-900">{investmentName}</h2>
+          {currentRecord?._updatedTime ? (
+            <p className="text-sm text-slate-500">
+              Updated {formatDate(currentRecord._updatedTime)}
+            </p>
+          ) : null}
+        </div>
+        <div className="flex items-center gap-2">
+          <RefreshStatus status={error ? "error" : status} />
+          <RefreshStatus status={docError ? "error" : docStatus} />
+        </div>
+      </div>
+
+      {hasLoaded && !currentRecord ? (
+        <div className="rounded-3xl border border-red-100 bg-red-50 p-8 text-sm text-red-600">
+          We couldn’t find that investment in your portfolio.
+        </div>
+      ) : null}
+
+      {currentRecord ? (
+        <div className="grid gap-6 lg:grid-cols-4">
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm lg:col-span-3">
+            <h3 className="text-lg font-semibold text-slate-900">Key metrics</h3>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Commitment</p>
+                <p className="mt-2 text-lg font-semibold text-slate-900">
+                  {commitment !== null ? formatCurrencyUSD(commitment) : "—"}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Total NAV</p>
+                <p className="mt-2 text-lg font-semibold text-slate-900">
+                  {nav !== null ? formatCurrencyUSD(nav) : "—"}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Distributions</p>
+                <p className="mt-2 text-lg font-semibold text-slate-900">
+                  {distributions !== null ? formatCurrencyUSD(distributions) : "—"}
+                </p>
+              </div>
+              <div>
+                <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Net MOIC</p>
+                <p className="mt-2 text-lg font-semibold text-slate-900">
+                  {netMoic !== null ? `${formatNumber(netMoic, 2)}x` : "—"}
+                </p>
+              </div>
+            </div>
+
+            <div className="mt-8">
+              <h4 className="text-sm font-semibold text-slate-700">NAV timeline</h4>
+              <div className="mt-3 h-72">
+                {timelineData.length ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={timelineData} margin={{ top: 10, right: 16, bottom: 0, left: 0 }}>
+                      <CartesianGrid strokeDasharray="3 3" stroke="#E2E8F0" />
+                      <XAxis dataKey="label" stroke="#64748B" tickLine={false} />
+                      <YAxis stroke="#64748B" tickFormatter={(value) => formatCurrencyUSD(value).replace("$", "")} />
+                      <Tooltip formatter={(value: number) => formatCurrencyUSD(value)} />
+                      <Line type="monotone" dataKey="value" stroke="#2563EB" strokeWidth={3} dot={{ r: 3 }} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <div className="flex h-full items-center justify-center rounded-2xl bg-slate-50 text-sm text-slate-500">
+                    No valuation history available yet.
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-4">
+            <h3 className="text-lg font-semibold text-slate-900">Key details</h3>
+            <dl className="space-y-3 text-sm text-slate-700">
+              {Object.entries(currentRecord.fields).map(([key, value]) => (
+                <div key={key} className="space-y-1">
+                  <dt className="text-xs font-semibold uppercase tracking-wide text-slate-400">{key}</dt>
+                  <dd className="text-sm text-slate-700">{formatFieldValue(key, value)}</dd>
+                </div>
+              ))}
+            </dl>
+          </div>
+        </div>
+      ) : !hasLoaded ? (
+        <div className="h-64 animate-pulse rounded-3xl bg-slate-100" />
+      ) : null}
+
+      <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div className="flex items-center justify-between">
+          <h3 className="text-lg font-semibold text-slate-900">Documents</h3>
+          <span className="text-xs text-slate-500">Latest PCAP, subscription and notices</span>
+        </div>
+        <div className="mt-4 space-y-3">
+          {docsLoaded ? (
+            documents.length ? (
+              documents.map((doc) => (
+                <div
+                  key={`${doc.investmentId}-${doc.name}-${doc.url}`}
+                  className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3"
+                >
+                  <div>
+                    <p className="font-medium text-slate-900">{doc.name}</p>
+                    <p className="text-xs text-slate-500">
+                      {doc.periodEnding ? `Period ending ${formatDate(doc.periodEnding)}` : "Recent"}
+                    </p>
+                  </div>
+                  <a
+                    href={doc.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center rounded-full bg-blue-600 px-4 py-2 text-xs font-semibold text-white hover:bg-blue-700"
+                  >
+                    Download
+                  </a>
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-slate-500">No documents uploaded for this investment yet.</p>
+            )
+          ) : (
+            <div className="h-24 animate-pulse rounded-2xl bg-slate-100" />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/lp/investments/page.tsx
+++ b/apps/web/app/lp/investments/page.tsx
@@ -1,0 +1,301 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import Link from "next/link";
+import { RefreshStatus } from "../components/RefreshStatus";
+import { usePollingResource } from "@/hooks/usePollingResource";
+import { formatCurrencyUSD, formatNumber, formatPercent } from "@/lib/format";
+
+interface LpRecord {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime: string | null;
+}
+
+interface LpDataResponse {
+  records: LpRecord[];
+}
+
+const CURRENCY_HINTS = [
+  "commitment",
+  "capital",
+  "nav",
+  "distribution",
+  "cost",
+  "contribution",
+  "value",
+];
+
+const PERCENT_HINTS = ["percent", "%", "irr", "moic", "multiple"];
+const DATE_HINTS = ["date", "period", "closing", "updated"];
+
+function coerceNumber(value: any): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.-]/g, "");
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function valueToText(value: any): string {
+  if (value === null || value === undefined) return "";
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => {
+        if (item && typeof item === "object") {
+          if ("displayName" in item) return String(item.displayName ?? "");
+          if ("filename" in item) return String((item as any).filename ?? (item as any).name ?? "");
+          if ("name" in item) return String((item as any).name ?? "");
+        }
+        return String(item ?? "");
+      })
+      .filter(Boolean)
+      .join("; ");
+  }
+  if (typeof value === "object") {
+    if ("displayName" in value) return String((value as any).displayName ?? "");
+    if ("name" in value) return String((value as any).name ?? "");
+  }
+  return String(value ?? "");
+}
+
+function formatCellValue(key: string, value: any) {
+  if (value === null || value === undefined || value === "") return "—";
+  const normalized = key.toLowerCase();
+
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "—";
+    if (value[0] && typeof value[0] === "object" && "url" in value[0]) {
+      return (
+        <div className="flex flex-wrap gap-2">
+          {value.map((item: any, idx: number) => (
+            <a
+              key={`${key}-${idx}`}
+              href={item.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center rounded-full border border-blue-200 px-3 py-1 text-xs text-blue-700 hover:bg-blue-50"
+            >
+              {(item.filename || item.name || "Document") as string}
+            </a>
+          ))}
+        </div>
+      );
+    }
+    return (
+      <div className="flex flex-wrap gap-2">
+        {value.map((item: any, idx: number) => {
+          const label =
+            (item && typeof item === "object" && "displayName" in item
+              ? (item.displayName as string)
+              : String(item ?? "")) || "—";
+          return (
+            <span
+              key={`${key}-chip-${idx}`}
+              className="rounded-full bg-slate-100 px-3 py-1 text-xs text-slate-700"
+            >
+              {label}
+            </span>
+          );
+        })}
+      </div>
+    );
+  }
+
+  if (typeof value === "number") {
+    if (CURRENCY_HINTS.some((hint) => normalized.includes(hint))) return formatCurrencyUSD(value);
+    if (PERCENT_HINTS.some((hint) => normalized.includes(hint))) return formatPercent(value);
+    return formatNumber(value);
+  }
+
+  if (typeof value === "string") {
+    if (DATE_HINTS.some((hint) => normalized.includes(hint))) return formatDate(value);
+    const numeric = coerceNumber(value);
+    if (numeric !== null && CURRENCY_HINTS.some((hint) => normalized.includes(hint))) {
+      return formatCurrencyUSD(numeric);
+    }
+    if (numeric !== null && PERCENT_HINTS.some((hint) => normalized.includes(hint))) {
+      return formatPercent(numeric);
+    }
+    return value;
+  }
+
+  return valueToText(value) || "—";
+}
+
+function escapeCsvValue(value: string) {
+  const needsQuotes = value.includes(",") || value.includes("\n") || value.includes("\"");
+  let escaped = value.replace(/"/g, '""');
+  if (needsQuotes) {
+    escaped = `"${escaped}"`;
+  }
+  return escaped;
+}
+
+export default function InvestmentsPage() {
+  const { data, status, error, hasLoaded } = usePollingResource<LpDataResponse>("/api/lp/data");
+  const [investmentQuery, setInvestmentQuery] = useState("");
+  const [fundQuery, setFundQuery] = useState("");
+  const [statusQuery, setStatusQuery] = useState("");
+
+  const records = data?.records ?? [];
+
+  const fieldKeys = useMemo(() => {
+    const set = new Set<string>();
+    records.forEach((record) => {
+      Object.keys(record.fields || {}).forEach((key) => set.add(key));
+    });
+    return Array.from(set);
+  }, [records]);
+
+  const filteredRecords = useMemo(() => {
+    const investFilter = investmentQuery.trim().toLowerCase();
+    const fundFilter = fundQuery.trim().toLowerCase();
+    const statusFilter = statusQuery.trim().toLowerCase();
+
+    return records.filter((record) => {
+      const fields = record.fields || {};
+      const investmentName = valueToText(
+        fields["Partner Investment"] ?? fields["Investment"] ?? fields["Name"] ?? ""
+      );
+      const fundName = valueToText(fields["Fund"] ?? fields["Entity"] ?? fields["JBV Entity"] ?? "");
+      const statusValue = valueToText(fields["Status"] ?? fields["Status (I)"] ?? "");
+
+      const matchesInvestment = !investFilter || investmentName.toLowerCase().includes(investFilter);
+      const matchesFund = !fundFilter || fundName.toLowerCase().includes(fundFilter);
+      const matchesStatus = !statusFilter || statusValue.toLowerCase().includes(statusFilter);
+
+      return matchesInvestment && matchesFund && matchesStatus;
+    });
+  }, [records, investmentQuery, fundQuery, statusQuery]);
+
+  function handleExport() {
+    if (!filteredRecords.length) return;
+    const headers = fieldKeys.map(escapeCsvValue).join(",");
+    const rows = filteredRecords.map((record) => {
+      const values = fieldKeys.map((key) => escapeCsvValue(valueToText(record.fields[key])));
+      return values.join(",");
+    });
+    const csvContent = [headers, ...rows].join("\n");
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `jbv-investments-${Date.now()}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900">Investments</h2>
+          <p className="text-sm text-slate-500">Search and export the holdings visible to your account.</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={handleExport}
+            className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-blue-300 hover:text-blue-700"
+            disabled={!filteredRecords.length}
+          >
+            Export CSV
+          </button>
+          <RefreshStatus status={error ? "error" : status} />
+        </div>
+      </div>
+
+      <div className="grid gap-4 md:grid-cols-3">
+        <label className="flex flex-col gap-1 text-sm text-slate-600">
+          Investment
+          <input
+            className="rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            value={investmentQuery}
+            onChange={(event) => setInvestmentQuery(event.target.value)}
+            placeholder="Search investment"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm text-slate-600">
+          Fund / Entity
+          <input
+            className="rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            value={fundQuery}
+            onChange={(event) => setFundQuery(event.target.value)}
+            placeholder="Search fund"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-sm text-slate-600">
+          Status
+          <input
+            className="rounded-full border border-slate-200 px-4 py-2 text-sm text-slate-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-100"
+            value={statusQuery}
+            onChange={(event) => setStatusQuery(event.target.value)}
+            placeholder="Search status"
+          />
+        </label>
+      </div>
+
+      <div className="overflow-x-auto rounded-3xl border border-slate-200 bg-white shadow-sm">
+        <table className="min-w-full divide-y divide-slate-200 text-sm">
+          <thead className="bg-slate-50">
+            <tr>
+              {fieldKeys.map((key) => (
+                <th
+                  key={key}
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-500"
+                >
+                  {key}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-slate-100">
+            {hasLoaded ? (
+              filteredRecords.length ? (
+                filteredRecords.map((record) => (
+                  <tr key={record.id} className="hover:bg-blue-50/40">
+                    {fieldKeys.map((key) => {
+                      const value = record.fields[key];
+                      const isInvestmentKey = ["Partner Investment", "Investment", "Name"].includes(key);
+                      return (
+                        <td key={`${record.id}-${key}`} className="px-4 py-3 align-top text-slate-700">
+                          {isInvestmentKey ? (
+                            <Link
+                              href={`/lp/investments/${record.id}`}
+                              className="font-medium text-blue-600 hover:underline"
+                            >
+                              {valueToText(value) || "View investment"}
+                            </Link>
+                          ) : (
+                            formatCellValue(key, value)
+                          )}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={fieldKeys.length} className="px-4 py-10 text-center text-sm text-slate-500">
+                    No investments match your filters.
+                  </td>
+                </tr>
+              )
+            ) : (
+              <tr>
+                <td colSpan={fieldKeys.length} className="px-4 py-10 text-center">
+                  <div className="mx-auto h-24 max-w-md animate-pulse rounded-2xl bg-slate-100" />
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/lp/layout.tsx
+++ b/apps/web/app/lp/layout.tsx
@@ -1,0 +1,26 @@
+import type { ReactNode } from "react";
+import NavTabs from "./NavTabs";
+
+export const metadata = {
+  title: "JBV Investment Platform | Limited Partner Portal",
+};
+
+export default function LpLayout({ children }: { children: ReactNode }) {
+  return (
+    <div className="min-h-screen bg-slate-50 text-slate-900">
+      <header className="border-b border-slate-200 bg-white">
+        <div className="mx-auto flex max-w-6xl flex-col gap-6 px-6 py-8">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.4em] text-blue-500">JBV Investment Platform</p>
+            <h1 className="mt-2 text-3xl font-semibold text-slate-900">Limited Partner Center</h1>
+            <p className="mt-2 max-w-3xl text-sm text-slate-500">
+              Monitor commitments, performance, and key documents with a clear, data-rich dashboard tailored for investors.
+            </p>
+          </div>
+          <NavTabs />
+        </div>
+      </header>
+      <main className="mx-auto flex max-w-6xl flex-col gap-8 px-6 py-10">{children}</main>
+    </div>
+  );
+}

--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -1,0 +1,305 @@
+"use client";
+
+import { useMemo } from "react";
+import {
+  Line,
+  LineChart,
+  CartesianGrid,
+  Tooltip,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+} from "recharts";
+import { RefreshStatus } from "./components/RefreshStatus";
+import { usePollingResource } from "@/hooks/usePollingResource";
+import { formatCurrencyUSD, formatNumber, formatDate } from "@/lib/format";
+
+interface LpRecord {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime: string | null;
+}
+
+interface Metrics {
+  commitmentTotal: number;
+  navTotal: number;
+  distributionsTotal: number;
+  netMoicAvg: number;
+}
+
+interface LpDataResponse {
+  records: LpRecord[];
+  metrics: Metrics;
+}
+
+function coerceNumber(value: any): number | null {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.-]/g, "");
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function getField<T = any>(fields: Record<string, any>, ...names: string[]): T | undefined {
+  for (const name of names) {
+    if (fields[name] !== undefined) return fields[name];
+  }
+  return undefined;
+}
+
+export default function LpOverviewPage() {
+  const { data, status, error, hasLoaded } = usePollingResource<LpDataResponse>("/api/lp/data");
+
+  const metrics: Metrics = data?.metrics ?? {
+    commitmentTotal: 0,
+    navTotal: 0,
+    distributionsTotal: 0,
+    netMoicAvg: 0,
+  };
+
+  const navSeries = useMemo(() => {
+    const map = new Map<
+      string,
+      {
+        nav: number;
+        distributions: number;
+        label: string;
+        sortValue: number;
+        hasPeriod: boolean;
+      }
+    >();
+
+    (data?.records ?? []).forEach((record) => {
+      const fields = record.fields || {};
+      const rawPeriod = getField<string>(fields, "Period Ending");
+      const navValue =
+        coerceNumber(getField(fields, "Total NAV")) ??
+        coerceNumber(getField(fields, "Current NAV")) ??
+        0;
+      const distValue = coerceNumber(getField(fields, "Distributions")) ?? 0;
+
+      const date = rawPeriod ? new Date(rawPeriod) : null;
+      const hasValidPeriod = Boolean(date && !Number.isNaN(date.getTime()));
+      const key = hasValidPeriod
+        ? date!.toISOString().slice(0, 10)
+        : rawPeriod ?? record.id;
+      const label = hasValidPeriod
+        ? date!.toLocaleDateString()
+        : rawPeriod ?? "Undated";
+      const sortValue = hasValidPeriod
+        ? date!.getTime()
+        : record._updatedTime
+        ? Date.parse(record._updatedTime)
+        : Date.now();
+
+      const existing = map.get(key);
+      if (existing) {
+        existing.nav += navValue;
+        existing.distributions += distValue;
+        existing.hasPeriod = existing.hasPeriod || hasValidPeriod;
+      } else {
+        map.set(key, {
+          nav: navValue,
+          distributions: distValue,
+          label,
+          sortValue: Number.isFinite(sortValue) ? sortValue : Date.now(),
+          hasPeriod: hasValidPeriod,
+        });
+      }
+    });
+
+    return Array.from(map.entries())
+      .map(([, value]) => value)
+      .sort((a, b) => a.sortValue - b.sortValue);
+  }, [data?.records]);
+
+  const hasPeriodData = navSeries.some((entry) => entry.hasPeriod);
+
+  const recentUpdates = useMemo(() => {
+    return [...(data?.records ?? [])]
+      .sort((a, b) => {
+        const aTime = a._updatedTime ? Date.parse(a._updatedTime) : 0;
+        const bTime = b._updatedTime ? Date.parse(b._updatedTime) : 0;
+        return bTime - aTime;
+      })
+      .slice(0, 5);
+  }, [data?.records]);
+
+  const totalsBarData = [
+    { label: "Total Commitment", value: metrics.commitmentTotal },
+    { label: "Total NAV", value: metrics.navTotal },
+    { label: "Distributions", value: metrics.distributionsTotal },
+  ];
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900">Portfolio Overview</h2>
+          <p className="text-sm text-slate-500">
+            Key performance indicators for your current JBV commitments.
+          </p>
+        </div>
+        <RefreshStatus status={error ? "error" : status} />
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-4">
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Total Commitment</p>
+          <p className="mt-3 text-2xl font-semibold text-slate-900">{formatCurrencyUSD(metrics.commitmentTotal)}</p>
+          <p className="mt-1 text-xs text-slate-500">
+            Committed capital across active investments.
+          </p>
+        </div>
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Total NAV</p>
+          <p className="mt-3 text-2xl font-semibold text-slate-900">{formatCurrencyUSD(metrics.navTotal)}</p>
+          <p className="mt-1 text-xs text-slate-500">
+            Net asset value as of the latest reporting period.
+          </p>
+        </div>
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Total Distributions</p>
+          <p className="mt-3 text-2xl font-semibold text-slate-900">{formatCurrencyUSD(metrics.distributionsTotal)}</p>
+          <p className="mt-1 text-xs text-slate-500">
+            Aggregate cash returned to date.
+          </p>
+        </div>
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <p className="text-xs font-semibold uppercase tracking-wide text-slate-400">Net MOIC</p>
+          <p className="mt-3 text-2xl font-semibold text-slate-900">
+            {metrics.netMoicAvg ? `${formatNumber(metrics.netMoicAvg, 2)}x` : "—"}
+          </p>
+          <p className="mt-1 text-xs text-slate-500">MOIC = Multiple on Invested Capital.</p>
+        </div>
+      </div>
+
+      <div className="grid gap-6 xl:grid-cols-2">
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-slate-900">NAV over time</h3>
+            <span className="text-xs text-slate-500">Period Ending vs. Total NAV</span>
+          </div>
+          <div className="mt-4 h-80">
+            {hasLoaded && hasPeriodData ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <LineChart data={navSeries} margin={{ top: 10, right: 16, bottom: 0, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#E2E8F0" />
+                  <XAxis dataKey="label" stroke="#64748B" tickLine={false} />
+                  <YAxis stroke="#64748B" tickFormatter={(value) => formatCurrencyUSD(value).replace("$", "")} />
+                  <Tooltip formatter={(value: number) => formatCurrencyUSD(value)} />
+                  <Line type="monotone" dataKey="nav" stroke="#2563EB" strokeWidth={3} dot={{ r: 3 }} />
+                </LineChart>
+              </ResponsiveContainer>
+            ) : hasLoaded ? (
+              <div className="flex h-full items-center justify-center text-sm text-slate-500">
+                Not enough period data to plot. Showing totals below.
+              </div>
+            ) : (
+              <div className="h-full animate-pulse rounded-2xl bg-slate-100" />
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-slate-900">Distributions by period</h3>
+            <span className="text-xs text-slate-500">Cash returned over time</span>
+          </div>
+          <div className="mt-4 h-80">
+            {hasLoaded && hasPeriodData ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={navSeries} margin={{ top: 10, right: 16, bottom: 0, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#E2E8F0" />
+                  <XAxis dataKey="label" stroke="#64748B" tickLine={false} />
+                  <YAxis stroke="#64748B" tickFormatter={(value) => formatCurrencyUSD(value).replace("$", "")} />
+                  <Tooltip formatter={(value: number) => formatCurrencyUSD(value)} />
+                  <Bar dataKey="distributions" fill="#0EA5E9" radius={[6, 6, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            ) : hasLoaded ? (
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={totalsBarData} margin={{ top: 10, right: 16, bottom: 0, left: 0 }}>
+                  <CartesianGrid strokeDasharray="3 3" stroke="#E2E8F0" />
+                  <XAxis dataKey="label" stroke="#64748B" tickLine={false} />
+                  <YAxis stroke="#64748B" tickFormatter={(value) => formatCurrencyUSD(value).replace("$", "")} />
+                  <Tooltip formatter={(value: number) => formatCurrencyUSD(value)} />
+                  <Bar dataKey="value" fill="#2563EB" radius={[6, 6, 0, 0]} />
+                </BarChart>
+              </ResponsiveContainer>
+            ) : (
+              <div className="h-full animate-pulse rounded-2xl bg-slate-100" />
+            )}
+          </div>
+        </div>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm lg:col-span-2">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-slate-900">Portfolio composition</h3>
+            <span className="text-xs text-slate-500">Latest updates ordered by modified date</span>
+          </div>
+          <div className="mt-4 space-y-3">
+            {hasLoaded && recentUpdates.length === 0 ? (
+              <p className="text-sm text-slate-500">No investments found for your account yet.</p>
+            ) : hasLoaded ? (
+              recentUpdates.map((record) => {
+                const fields = record.fields || {};
+                const investmentName =
+                  getField<string>(fields, "Partner Investment", "Investment", "Name") ?? "Investment";
+                const fundName = getField<string>(fields, "Fund", "Entity", "JBV Entity");
+                const status = getField<string>(fields, "Status", "Status (I)");
+                return (
+                  <div
+                    key={record.id}
+                    className="flex flex-col gap-1 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 md:flex-row md:items-center md:justify-between"
+                  >
+                    <div>
+                      <p className="font-medium text-slate-900">{investmentName}</p>
+                      <p className="text-xs text-slate-500">
+                        {fundName ? `${fundName} · ` : ""}
+                        Updated {record._updatedTime ? formatDate(record._updatedTime) : "recently"}
+                      </p>
+                    </div>
+                    {status ? (
+                      <span className="inline-flex w-fit items-center rounded-full bg-blue-100 px-3 py-1 text-xs font-medium text-blue-700">
+                        {status}
+                      </span>
+                    ) : null}
+                  </div>
+                );
+              })
+            ) : (
+              <div className="space-y-3">
+                {Array.from({ length: 3 }).map((_, idx) => (
+                  <div key={idx} className="h-16 animate-pulse rounded-2xl bg-slate-100" />
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+          <h3 className="text-lg font-semibold text-slate-900">Investor insights</h3>
+          <ul className="mt-4 space-y-3 text-sm text-slate-600">
+            <li>
+              <span className="font-semibold text-slate-800">MOIC</span> measures total value divided by invested capital.
+            </li>
+            <li>
+              NAV trends provide a directional view of valuation changes across reporting periods.
+            </li>
+            <li>
+              Distribution totals reflect cumulative cash returned, inclusive of PCAP distributions.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/hooks/usePollingResource.ts
+++ b/apps/web/hooks/usePollingResource.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type PollingStatus = "idle" | "refreshing" | "error";
+
+interface Options {
+  intervalMs?: number;
+}
+
+export function usePollingResource<T>(url: string, options: Options = {}) {
+  const { intervalMs = 15000 } = options;
+  const [data, setData] = useState<T | null>(null);
+  const [status, setStatus] = useState<PollingStatus>("refreshing");
+  const [error, setError] = useState<Error | null>(null);
+  const [hasLoaded, setHasLoaded] = useState(false);
+  const fetchingRef = useRef(false);
+
+  const refresh = useCallback(async () => {
+    if (fetchingRef.current) return;
+    fetchingRef.current = true;
+    setStatus("refreshing");
+    try {
+      const response = await fetch(url, { cache: "no-store" });
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+      const json = (await response.json()) as T;
+      setData(json);
+      setError(null);
+      setHasLoaded(true);
+      setStatus("idle");
+    } catch (err) {
+      setError(err as Error);
+      setStatus("error");
+    } finally {
+      fetchingRef.current = false;
+    }
+  }, [url]);
+
+  useEffect(() => {
+    refresh();
+    const id = window.setInterval(() => {
+      refresh();
+    }, intervalMs);
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [intervalMs, refresh]);
+
+  useEffect(() => {
+    const handler = () => {
+      refresh();
+    };
+    window.addEventListener("focus", handler);
+    return () => {
+      window.removeEventListener("focus", handler);
+    };
+  }, [refresh]);
+
+  return { data, status, error, refresh, hasLoaded } as const;
+}

--- a/apps/web/lib/airtablePartnerInvestments.ts
+++ b/apps/web/lib/airtablePartnerInvestments.ts
@@ -1,0 +1,187 @@
+import Airtable from "airtable";
+import Bottleneck from "bottleneck";
+
+const base = new Airtable({ apiKey: process.env.AIRTABLE_API_KEY! }).base(
+  process.env.AIRTABLE_BASE_ID!
+);
+
+const VIEW_ID = process.env.AIRTABLE_VIEW_ID || undefined;
+
+const LINK_MAP: Record<string, string> = {
+  "Target Securities": "Target Securities",
+  Partner: "Partners",
+  Fund: "JBV Entities",
+  "PRIMARY CONTACT": "Contacts",
+  "Primary Contact": "Contacts",
+};
+
+const limiter = new Bottleneck({ minTime: 60 });
+
+export const PARTNER_INVESTMENTS_TABLE = "Partner Investments";
+
+export type AirtableRecord = Airtable.Record<any>;
+
+export type LinkedRecord = {
+  id: string;
+  fields: Record<string, any>;
+  displayName: any;
+};
+
+export type ExpandedRecord = {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime: string | null;
+};
+
+const EMAIL_FIELD_FORMULAS: Array<{
+  field: string;
+  build: (email: string) => string;
+}> = [
+  {
+    field: "PrimaryContactEmailCSV",
+    build: (email) => `FIND(LOWER('${email}'), LOWER({PrimaryContactEmailCSV})) > 0`,
+  },
+  {
+    field: "Primary Contact Email",
+    build: (email) => `LOWER({Primary Contact Email})='${email}'`,
+  },
+  {
+    field: "PRIMARY CONTACT Email",
+    build: (email) => `LOWER({PRIMARY CONTACT Email})='${email}'`,
+  },
+];
+
+const CHUNK_SIZE = 50;
+
+function sanitizeEmailForFormula(email: string) {
+  return email.replace(/'/g, "\\'").toLowerCase();
+}
+
+function toLinkedRecord(rec: AirtableRecord): LinkedRecord {
+  const fields: any = rec.fields || {};
+  const primary = fields.Name || fields.Title || Object.values(fields || {})[0];
+  return { id: rec.id, fields, displayName: primary };
+}
+
+async function fetchLinkedRecords(tableName: string, ids: string[]) {
+  if (!ids.length) return new Map<string, LinkedRecord>();
+  const uniqueIds = Array.from(new Set(ids));
+  const lookup = new Map<string, LinkedRecord>();
+
+  for (let i = 0; i < uniqueIds.length; i += CHUNK_SIZE) {
+    const chunk = uniqueIds.slice(i, i + CHUNK_SIZE);
+    const filterByFormula =
+      chunk.length === 1
+        ? `RECORD_ID()='${chunk[0]}'`
+        : `OR(${chunk.map((id) => `RECORD_ID()='${id}'`).join(",")})`;
+
+    const records = await limiter.schedule(() =>
+      base(tableName)
+        .select({ filterByFormula })
+        .all()
+    );
+
+    for (const rec of records) {
+      const formatted = toLinkedRecord(rec as AirtableRecord);
+      lookup.set(formatted.id, formatted);
+    }
+  }
+
+  return lookup;
+}
+
+export async function expandPartnerInvestmentRecords(
+  rows: AirtableRecord[]
+): Promise<ExpandedRecord[]> {
+  if (!rows.length) return [];
+
+  const idsByTable = new Map<string, Set<string>>();
+
+  for (const row of rows) {
+    const rowFields: Record<string, any> = (row.fields || {}) as Record<string, any>;
+    for (const [fieldName, tableName] of Object.entries(LINK_MAP)) {
+      const value = rowFields[fieldName];
+      if (Array.isArray(value) && value.length) {
+        if (!idsByTable.has(tableName)) idsByTable.set(tableName, new Set());
+        const idSet = idsByTable.get(tableName)!;
+        for (const id of value) idSet.add(id);
+      }
+    }
+  }
+
+  const lookups = new Map<string, Map<string, LinkedRecord>>();
+
+  await Promise.all(
+    Array.from(idsByTable.entries()).map(async ([tableName, idSet]) => {
+      const tableLookup = await fetchLinkedRecords(tableName, Array.from(idSet));
+      lookups.set(tableName, tableLookup);
+    })
+  );
+
+  return rows.map((row) => {
+    const originalFields: Record<string, any> = (row.fields || {}) as Record<string, any>;
+    const fields: Record<string, any> = { ...originalFields };
+
+    for (const [fieldName, tableName] of Object.entries(LINK_MAP)) {
+      const ids = originalFields[fieldName];
+      if (Array.isArray(ids) && ids.length) {
+        const lookup = lookups.get(tableName);
+        fields[fieldName] = lookup
+          ? ids.map((id: string) => lookup.get(id) ?? { id, error: true })
+          : [];
+      }
+    }
+
+    return {
+      id: row.id,
+      fields,
+      _updatedTime: (row as any)._rawJson?.modifiedTime || null,
+    };
+  });
+}
+
+export async function selectPartnerInvestments(filterByFormula?: string) {
+  return limiter.schedule(() =>
+    base(PARTNER_INVESTMENTS_TABLE)
+      .select({
+        ...(VIEW_ID ? { view: VIEW_ID } : {}),
+        ...(filterByFormula ? { filterByFormula } : {}),
+      })
+      .all()
+  );
+}
+
+export async function selectPartnerInvestmentsByEmail(email: string) {
+  const sanitized = sanitizeEmailForFormula(email);
+  let lastError: unknown = null;
+
+  for (const candidate of EMAIL_FIELD_FORMULAS) {
+    const filterByFormula = candidate.build(sanitized);
+    try {
+      const rows = await selectPartnerInvestments(filterByFormula);
+      return { rows, filterByFormula, field: candidate.field };
+    } catch (error: any) {
+      if (error?.statusCode === 422 || error?.statusCode === 400) {
+        lastError = error;
+        continue;
+      }
+      throw error;
+    }
+  }
+
+  if (lastError) {
+    throw lastError;
+  }
+
+  return { rows: [] as AirtableRecord[], filterByFormula: undefined, field: undefined };
+}
+
+export async function fetchVisibilityRules() {
+  return limiter.schedule(() =>
+    base("VisibilityRules")
+      .select({
+        filterByFormula: "{tableId}='Partner Investments'",
+      })
+      .all()
+  );
+}

--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -1,0 +1,26 @@
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { authOptions } from "@/app/api/auth/[...nextauth]/route";
+import type { Session } from "next-auth";
+
+export async function getSession(): Promise<Session | null> {
+  return getServerSession(authOptions);
+}
+
+export async function requireSession(): Promise<Session> {
+  const session = await getSession();
+  if (!session || !session.user?.email) {
+    redirect("/auth/signin");
+  }
+  return session;
+}
+
+export function isAdmin(email?: string | null): boolean {
+  if (!email) return false;
+  const raw = process.env.ADMIN_EMAILS || "";
+  const list = raw
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter(Boolean);
+  return list.includes(email.toLowerCase());
+}

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { getToken } from "next-auth/jwt";
+
+const PUBLIC_FILE = /\.(.*)$/;
+
+function createSignInRedirect(req: NextRequest) {
+  const signInUrl = new URL("/auth/signin", req.url);
+  const callbackPath = `${req.nextUrl.pathname}${req.nextUrl.search}`;
+  if (callbackPath && callbackPath !== "/auth/signin") {
+    signInUrl.searchParams.set("callbackUrl", callbackPath);
+  }
+  return NextResponse.redirect(signInUrl);
+}
+
+export async function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+
+  if (
+    pathname === "/" ||
+    pathname.startsWith("/auth") ||
+    pathname.startsWith("/api/auth") ||
+    PUBLIC_FILE.test(pathname)
+  ) {
+    return NextResponse.next();
+  }
+
+  const token = await getToken({ req, secret: process.env.NEXTAUTH_SECRET });
+  const isAuthenticated = Boolean(token?.email);
+  const role = token?.role as string | undefined;
+
+  if (pathname.startsWith("/admin")) {
+    if (!isAuthenticated) {
+      return createSignInRedirect(req);
+    }
+    if (role !== "admin") {
+      return NextResponse.redirect(new URL("/lp", req.url));
+    }
+    return NextResponse.next();
+  }
+
+  if (pathname.startsWith("/lp")) {
+    if (!isAuthenticated) {
+      return createSignInRedirect(req);
+    }
+    return NextResponse.next();
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!_next/static|_next/image|favicon.ico|robots.txt|sitemap.xml).*)"],
+};

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -8,12 +8,19 @@
       "name": "web",
       "version": "0.1.0",
       "dependencies": {
+        "@auth/core": "^0.34.2",
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
         "@tanstack/react-table": "^8.13.0",
+        "@tanstack/react-virtual": "^3.13.12",
         "airtable": "^0.11.6",
         "bottleneck": "^2.19.5",
+        "google-auth-library": "^10.3.0",
         "next": "^14.2.32",
+        "next-auth": "^4.24.11",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "recharts": "^3.2.1"
       },
       "devDependencies": {
         "@types/node": "^20.12.12",
@@ -36,6 +43,99 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@auth/core": {
+      "version": "0.34.2",
+      "resolved": "https://registry.npmjs.org/@auth/core/-/core-0.34.2.tgz",
+      "integrity": "sha512-KywHKRgLiF3l7PLyL73fjLSIBe1YNcA6sMeew4yMP6cfCWGXZrkkXd32AjRi1hlJ9nvovUBGZHvbn+LijO6ZeQ==",
+      "license": "ISC",
+      "dependencies": {
+        "@panva/hkdf": "^1.1.1",
+        "@types/cookie": "0.6.0",
+        "cookie": "0.6.0",
+        "jose": "^5.1.3",
+        "oauth4webapi": "^2.10.4",
+        "preact": "10.11.3",
+        "preact-render-to-string": "5.2.3"
+      },
+      "peerDependencies": {
+        "@simplewebauthn/browser": "^9.0.1",
+        "@simplewebauthn/server": "^9.0.2",
+        "nodemailer": "^6.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@simplewebauthn/browser": {
+          "optional": true
+        },
+        "@simplewebauthn/server": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@dnd-kit/accessibility": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+      "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/core": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+      "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/accessibility": "^3.1.1",
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/sortable": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+      "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
+      "license": "MIT",
+      "dependencies": {
+        "@dnd-kit/utilities": "^3.2.2",
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@dnd-kit/core": "^6.3.0",
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@dnd-kit/utilities": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+      "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -283,6 +383,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -293,6 +402,44 @@
       "engines": {
         "node": ">=14"
       }
+    },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.9.0.tgz",
+      "integrity": "sha512-fSfQlSRu9Z5yBkvsNhYF2rPS8cGXn/TZVrlwN1948QyZ8xMZ0JvP50S2acZNaf+o63u6aEeMjipFyksjIcWrog==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^10.0.3",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
@@ -330,6 +477,23 @@
         "react-dom": ">=16.8"
       }
     },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.12.tgz",
+      "integrity": "sha512-Gd13QdxPSukP8ZrkbgS2RwoZseTTbQPLnQEn7HY/rqtM+8Zt95f7xKC7N0EsKs7aoz0WzZ+fditZux+F8EzYxA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.12"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@tanstack/table-core": {
       "version": "8.21.3",
       "resolved": "https://registry.npmjs.org/@tanstack/table-core/-/table-core-8.21.3.tgz",
@@ -342,6 +506,85 @@
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.12",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.12.tgz",
+      "integrity": "sha512-1YBOJfRHV4sXUmWsFSf5rQor4Ss82G8dQWLRbnk3GA4jeP8hQt1hxXh0tmflpC0dz3VgEv/1+qwPyLeWkQuPFA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@types/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@types/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.7.tgz",
+      "integrity": "sha512-VLvUQ33C+3J+8p+Daf+nYSOsjB4GXp19/S/aGo60m9h1v6XaxjiT82lKVWJCfzhtuZ3yD7i/TPeC/fuKLLOSmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "20.19.15",
@@ -357,14 +600,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -380,6 +623,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -398,6 +647,15 @@
       "resolved": "https://registry.npmjs.org/abortcontroller-polyfill/-/abortcontroller-polyfill-1.7.8.tgz",
       "integrity": "sha512-9f1iZ2uWh92VcrU9Y8x+LdM4DLj75VE0MJB8zuF1iUnroEptStw+DQ8EQPMUdfe5k+PkB1uUfDQfWbhstH8LrQ==",
       "license": "MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/airtable": {
       "version": "0.11.6",
@@ -520,6 +778,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.4",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.4.tgz",
@@ -528,6 +806,15 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/binary-extensions": {
@@ -605,6 +892,12 @@
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/busboy": {
       "version": "1.6.0",
@@ -691,6 +984,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -719,6 +1021,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
+      "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/cross-spawn": {
@@ -753,7 +1064,160 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
       "license": "MIT"
     },
     "node_modules/didyoumean": {
@@ -777,6 +1241,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.218",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.218.tgz",
@@ -790,6 +1263,16 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-toolkit": {
+      "version": "1.39.10",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.39.10.tgz",
+      "integrity": "sha512-E0iGnTtbDhkeczB0T+mxmoVlT4YNweEKBLq7oaU4p11mecdsZpNWOglI4895Vh4usbQ+LsJiuLuI2L0Vdmfm2w==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
     },
     "node_modules/escalade": {
       "version": "3.2.0",
@@ -809,6 +1292,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -850,6 +1345,29 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -878,6 +1396,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fraction.js": {
@@ -919,6 +1449,52 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.1.tgz",
+      "integrity": "sha512-Odju3uBUJyVCkW64nLD4wKLhbh93bh6vIg/ZIXkWiLPBrdgtc65+tls/qml+un3pr6JqYVFDZbbmLDQT68rTOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gaxios/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-7.0.1.tgz",
+      "integrity": "sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -953,11 +1529,51 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.3.0.tgz",
+      "integrity": "sha512-ylSE3RlCRZfZB56PFJSfUCuiuPq83Fx8hqu1KPWGK8FVdSaxlp/qkeMMX/DT/18xkwXIHvXEXkZsljRwfrdEfQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.0.0",
+        "gcp-metadata": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "gtoken": "^8.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.1.tgz",
+      "integrity": "sha512-rcX58I7nqpu4mbKztFeOAObbomBbHU2oIb/d3tJfF3dizGSApqtSwYJigGCooHdnMyQBIw8BrWyK96w3YXgr6A==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
+    },
+    "node_modules/gtoken": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-8.0.0.tgz",
+      "integrity": "sha512-+CqsMbHPiSTdtSO14O51eMNlrp9N79gmeqmXeouJOhfucAedHw9noVe/n5uJk3tbKE6a+6ZCQg3RPhVhHByAIw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/hasown": {
       "version": "2.0.2",
@@ -970,6 +1586,38 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.1.3",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.1.3.tgz",
+      "integrity": "sha512-tmjF/k8QDKydUlm3mZU+tjM6zeq9/fFpPqH9SzWmBnVVKsPBg/V66qsMwb3/Bo90cgUN+ghdVBess+hPsxUyRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-binary-path": {
@@ -1077,11 +1725,50 @@
         "jiti": "bin/jiti.js"
       }
     },
+    "node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -1178,6 +1865,12 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -1258,6 +1951,56 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/next-auth/node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/next-auth/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -1284,6 +2027,26 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
       }
     },
     "node_modules/node-fetch": {
@@ -1333,6 +2096,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
+    "node_modules/oauth4webapi": {
+      "version": "2.17.0",
+      "resolved": "https://registry.npmjs.org/oauth4webapi/-/oauth4webapi-2.17.0.tgz",
+      "integrity": "sha512-lbC0Z7uzAFNFyzEYRIC+pkSVvDHJTbEW+dYlSBAlCYDe6RxUkJ26bClhk8ocBZip1wfI9uKTe0fm4Ib4RHn6uQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -1348,6 +2126,60 @@
       "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/oidc-token-hash": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
+      "integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/openid-client/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
       "license": "MIT",
       "engines": {
         "node": ">= 6"
@@ -1553,6 +2385,34 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/preact": {
+      "version": "10.11.3",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.11.3.tgz",
+      "integrity": "sha512-eY93IVpod/zG3uMF22Unl8h9KkrcKIRs2EGar8hwLZZDU1lkjph303V9HZBwufh2s736U6VXuhD109LYqPoffg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.3.tgz",
+      "integrity": "sha512-aPDxUn5o3GhWdtJtW0svRC2SS/l8D9MAgo2+AWml+BhDImb27ALf04Q2d+AHqUUOc6RdSXFIBVa2gxzgMKgtZA==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -1599,6 +2459,36 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
+      "integrity": "sha512-tr41fA15Vn8p4X9ntI+yCyeGSf1TlYaY5vlTZfQmeLBrFo3psOPX6HhTDnFNL9uj3EhP0KAQ80cugCl4b4BERA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -1621,6 +2511,54 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.2.1.tgz",
+      "integrity": "sha512-0JKwHRiFZdmLq/6nmilxEZl3pqb4T+aKkOkOi/ZISRZwfBhVMgInxzlYU9D4KnCH3KINScLy68m/OvMXoYGZUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reduxjs/toolkit": "1.x.x || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/resolve": {
       "version": "1.22.10",
@@ -1677,6 +2615,26 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/scheduler": {
       "version": "0.23.2",
@@ -2000,6 +2958,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -2084,12 +3048,61 @@
         "browserslist": ">= 4.21.0"
       }
     },
+    "node_modules/use-sync-external-store": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.5.0.tgz",
+      "integrity": "sha512-Rb46I4cGGVBmjamjphe8L/UnvJD+uPPtTkNvX5mZgqdbavhI4EbgIWJiIHXJ8bc/i9EQGPRh4DwEURJ552Do0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -2220,6 +3233,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     },
     "node_modules/yaml": {
       "version": "2.8.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -9,15 +9,19 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@auth/core": "^0.34.2",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@tanstack/react-table": "^8.13.0",
     "@tanstack/react-virtual": "^3.13.12",
     "airtable": "^0.11.6",
     "bottleneck": "^2.19.5",
+    "google-auth-library": "^10.3.0",
     "next": "^14.2.32",
+    "next-auth": "^4.24.11",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "recharts": "^3.2.1"
   },
   "devDependencies": {
     "@types/node": "^20.12.12",

--- a/apps/web/types/next-auth.d.ts
+++ b/apps/web/types/next-auth.d.ts
@@ -1,0 +1,23 @@
+import NextAuth from "next-auth";
+import "next-auth/jwt";
+
+declare module "next-auth" {
+  interface Session {
+    user?: {
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+      role?: "admin" | "lp";
+    };
+  }
+
+  interface User {
+    role?: "admin" | "lp";
+  }
+}
+
+declare module "next-auth/jwt" {
+  interface JWT {
+    role?: "admin" | "lp";
+  }
+}


### PR DESCRIPTION
## Summary
- integrate NextAuth with email/Google providers, role-aware sessions, middleware protections, and a branded sign-in experience
- add Airtable-backed LP APIs that filter partner investments by the logged-in contact, enforce visibility rules, and compute portfolio metrics and documents
- build the authenticated LP portal with overview KPIs/charts, searchable investments table, investment detail view, documents center, help content, and shared polling utilities

## Testing
- ⚠️ `npm run lint` *(could not complete because Next.js prompted for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_b_68c9dfbd7efc8320bd268a3f2fcee7c4