### PR TITLE
Fix magic link email configuration

### DIFF
--- a/apps/web/lib/auth-options.ts
+++ b/apps/web/lib/auth-options.ts
@@ -1,20 +1,82 @@
 import { type NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
-import EmailProvider from "next-auth/providers/email";
+import EmailProvider, { type EmailConfig } from "next-auth/providers/email";
 import GoogleProvider from "next-auth/providers/google";
 
 import { getAdminEmails, isAdmin } from "./auth-helpers";
 
+function resolveEmailServer(): EmailConfig["server"] | null {
+  const directServer = process.env.EMAIL_SERVER?.trim();
+  if (directServer) {
+    return directServer;
+  }
+
+  const host = process.env.EMAIL_SERVER_HOST?.trim();
+  const portValue = process.env.EMAIL_SERVER_PORT?.trim();
+  const user = process.env.EMAIL_SERVER_USER?.trim();
+  const password = process.env.EMAIL_SERVER_PASSWORD?.trim();
+  const secureValue = process.env.EMAIL_SERVER_SECURE?.trim();
+
+  const hasPartialConfig = Boolean(host || portValue || user || password || secureValue);
+  if (!hasPartialConfig) {
+    return null;
+  }
+
+  if (!host || !portValue) {
+    console.warn(
+      "[auth] EMAIL_SERVER_HOST and EMAIL_SERVER_PORT must be configured when EMAIL_SERVER is not provided."
+    );
+    return null;
+  }
+
+  const port = Number.parseInt(portValue, 10);
+  if (Number.isNaN(port)) {
+    console.warn(`[auth] EMAIL_SERVER_PORT must be a valid number. Received: ${portValue}`);
+    return null;
+  }
+
+  const secure = secureValue
+    ? secureValue.toLowerCase() === "true"
+    : port === 465;
+
+  const server: {
+    host: string;
+    port: number;
+    secure: boolean;
+    auth?: {
+      user: string;
+      pass: string;
+    };
+  } = {
+    host,
+    port,
+    secure,
+  };
+
+  if (user && password) {
+    server.auth = { user, pass: password };
+  } else if (user || password) {
+    console.warn(
+      "[auth] Both EMAIL_SERVER_USER and EMAIL_SERVER_PASSWORD must be provided to configure SMTP authentication."
+    );
+  }
+
+  return server;
+}
+
 function buildProviders(): NextAuthOptions["providers"] {
   const providers: NextAuthOptions["providers"] = [];
 
-  if (process.env.EMAIL_SERVER && process.env.EMAIL_FROM) {
+  const emailServer = resolveEmailServer();
+  if (emailServer && process.env.EMAIL_FROM) {
     providers.push(
       EmailProvider({
-        server: process.env.EMAIL_SERVER,
+        server: emailServer,
         from: process.env.EMAIL_FROM,
       })
     );
+  } else if (emailServer && !process.env.EMAIL_FROM) {
+    console.warn("[auth] EMAIL_FROM must be configured to send magic link emails.");
   }
 
   if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -18,6 +18,7 @@
         "google-auth-library": "^10.3.0",
         "next": "^14.2.32",
         "next-auth": "^4.24.11",
+        "nodemailer": "^6.10.1",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "recharts": "^3.2.1"
@@ -5097,6 +5098,15 @@
       "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "google-auth-library": "^10.3.0",
     "next": "^14.2.32",
     "next-auth": "^4.24.11",
+    "nodemailer": "^6.10.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "recharts": "^3.2.1"


### PR DESCRIPTION
## Summary
- add the required nodemailer dependency so NextAuth can send email magic links
- accept SMTP host/port/user/password environment variables and warn about misconfiguration when building the email provider

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cacddbc408832089bcbb00eee67add