### PR TITLE
Implement email-only LP authentication and secure document proxy

### DIFF
--- a/apps/web/app/admin/head.tsx
+++ b/apps/web/app/admin/head.tsx
@@ -1,0 +1,7 @@
+export default function Head() {
+  return (
+    <>
+      <meta name="robots" content="noindex, nofollow" />
+    </>
+  );
+}

--- a/apps/web/app/api/lp/documents/download/route.ts
+++ b/apps/web/app/api/lp/documents/download/route.ts
@@ -1,0 +1,62 @@
+import { getSession } from "@/lib/auth";
+import { type Role } from "@/lib/auth-helpers";
+import { PARTNER_INVESTMENTS_TABLE, base } from "@/lib/airtable";
+import { loadPartnerInvestmentRecords } from "@/lib/lp-server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+function parseIndex(value: string | null): number {
+  if (!value) return 0;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const recordId = searchParams.get("recordId");
+    const field = searchParams.get("field");
+    const index = parseIndex(searchParams.get("index"));
+
+    if (!recordId || !field) {
+      return new Response("Missing parameters", { status: 400 });
+    }
+
+    const session = await getSession();
+    const user = session?.user;
+    const email = user?.email;
+    if (!session || !user || !email) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+
+    const role = (user.role as Role | undefined) ?? "lp";
+    const { records } = await loadPartnerInvestmentRecords(email, role);
+    const record = records.find((item) => item.id === recordId);
+    if (!record) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    const visibleFields = record.fields || {};
+    if (!Object.prototype.hasOwnProperty.call(visibleFields, field)) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    const airtableRecord = await base(PARTNER_INVESTMENTS_TABLE).find(recordId);
+    const rawField = (airtableRecord.fields || {})[field as keyof typeof airtableRecord.fields];
+
+    if (!Array.isArray(rawField) || rawField.length === 0) {
+      return new Response("File not found", { status: 404 });
+    }
+
+    const attachment = rawField[index];
+    if (!attachment || typeof attachment.url !== "string") {
+      return new Response("File not found", { status: 404 });
+    }
+
+    return Response.redirect(attachment.url, 302);
+  } catch (error) {
+    console.error("[documents] Failed to proxy download", error);
+    return new Response("Unable to download document", { status: 500 });
+  }
+}

--- a/apps/web/app/api/lp/documents/route.ts
+++ b/apps/web/app/api/lp/documents/route.ts
@@ -6,8 +6,8 @@ export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
 
 type Attachment = {
-  name: string;
-  url: string;
+  name?: string;
+  url?: string;
   size?: number;
   type?: string;
   filename?: string;
@@ -52,12 +52,13 @@ export async function GET() {
 
     const documents: Array<{
       name: string;
-      url: string;
       size?: number;
       type?: string;
       investmentId: string;
       investmentName?: string;
       periodEnding?: any;
+      field: string;
+      index: number;
     }> = [];
 
     for (const record of records) {
@@ -65,21 +66,22 @@ export async function GET() {
       const investmentName = resolveInvestmentName(fields);
       const periodEnding = resolvePeriodEnding(fields);
 
-      for (const value of Object.values(fields)) {
+      for (const [fieldName, value] of Object.entries(fields)) {
         if (!Array.isArray(value)) continue;
-        for (const entry of value) {
+        value.forEach((entry, index) => {
           if (isAttachment(entry)) {
             documents.push({
               name: entry.name || entry.filename || "Document",
-              url: entry.url,
               size: entry.size,
               type: entry.type,
               investmentId: record.id,
               investmentName,
               periodEnding,
+              field: fieldName,
+              index,
             });
           }
-        }
+        });
       }
     }
 

--- a/apps/web/app/auth/signin/page.tsx
+++ b/apps/web/app/auth/signin/page.tsx
@@ -1,87 +1,48 @@
 "use client";
 
-import { FormEvent, Suspense, useState } from "react";
+import { FormEvent, useMemo, useState } from "react";
 import { signIn } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
 
-export default function SignInPage() {
-  return (
-    <Suspense
-      fallback={
-        <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center px-4 py-16">
-          <div className="w-full max-w-md space-y-4 text-center">
-            <div className="mx-auto h-12 w-12 animate-pulse rounded-full bg-blue-100" />
-            <p className="text-sm text-slate-500">Preparing secure sign-in options…</p>
-          </div>
-        </div>
-      }
-    >
-      <SignInContent />
-    </Suspense>
-  );
-}
+const ERROR_MESSAGES: Record<string, string> = {
+  CredentialsSignin: "We couldn't find that email in our investor records.",
+  AccessDenied: "You do not have permission to access this area.",
+};
 
-function SignInContent() {
+export default function SignInPage() {
   const searchParams = useSearchParams();
   const [email, setEmail] = useState("");
-  const [emailStatus, setEmailStatus] = useState<"idle" | "sending" | "sent" | "error">("idle");
+  const [status, setStatus] = useState<"idle" | "submitting">("idle");
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
-  const [adminEmail, setAdminEmail] = useState("jb@jbv.com");
-  const [adminPassword, setAdminPassword] = useState("");
-  const [adminStatus, setAdminStatus] = useState<"idle" | "signing-in" | "error">("idle");
-  const [adminErrorMessage, setAdminErrorMessage] = useState<string | null>(null);
 
   const callbackUrl = searchParams?.get("callbackUrl") || "/lp";
 
-  const handleEmailSignIn = async (event: FormEvent<HTMLFormElement>) => {
+  const queryError = useMemo(() => {
+    const errorKey = searchParams?.get("error");
+    if (!errorKey) return null;
+    return ERROR_MESSAGES[errorKey] || "We were unable to sign you in. Please try again.";
+  }, [searchParams]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setEmailStatus("sending");
+    setStatus("submitting");
     setErrorMessage(null);
+
     try {
-      const result = await signIn("email", {
+      const result = await signIn("credentials", {
         email,
-        redirect: false,
         callbackUrl,
+        redirect: false,
       });
 
-      if (result?.error) {
-        setEmailStatus("error");
-        if (result.error === "CredentialsSignin") {
-          setErrorMessage("This email is not authorized to access the portal.");
-        } else {
-          setErrorMessage(result.error);
-        }
+      if (!result) {
+        setErrorMessage("Unexpected authentication response. Please try again.");
         return;
       }
 
-      if (result?.url) {
-        window.location.href = result.url;
-        return;
-      }
-
-      setEmailStatus("sent");
-    } catch (err: any) {
-      setEmailStatus("error");
-      setErrorMessage(err?.message || "Failed to send sign-in link.");
-    }
-  };
-
-  const handleAdminSignIn = async (event: FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setAdminStatus("signing-in");
-    setAdminErrorMessage(null);
-
-    try {
-      const result = await signIn("admin-login", {
-        email: adminEmail,
-        password: adminPassword,
-        redirect: false,
-        callbackUrl,
-      });
-
-      if (!result || result.error) {
-        setAdminStatus("error");
-        setAdminErrorMessage("Invalid admin email or password.");
+      if (result.error) {
+        const friendly = ERROR_MESSAGES[result.error] || "We couldn't verify that email.";
+        setErrorMessage(friendly);
         return;
       }
 
@@ -90,118 +51,68 @@ function SignInContent() {
         return;
       }
 
-      if (result.ok) {
-        window.location.href = callbackUrl;
-        return;
-      }
-
-      setAdminStatus("error");
-      setAdminErrorMessage("Unable to sign in with admin credentials.");
-    } catch (err: any) {
-      setAdminStatus("error");
-      setAdminErrorMessage(err?.message || "Unable to sign in with admin credentials.");
+      window.location.href = callbackUrl;
+    } catch (error) {
+      console.error("[auth] Email sign-in failed", error);
+      setErrorMessage("We couldn't verify that email. Please try again or contact support.");
+    } finally {
+      setStatus("idle");
     }
   };
 
   return (
-    <div className="min-h-screen bg-slate-50 flex flex-col items-center justify-center px-4 py-16">
+    <div className="flex min-h-screen items-center justify-center bg-slate-50 px-4 py-16">
       <div className="w-full max-w-md space-y-8">
-        <div className="text-center space-y-3">
-          <div className="mx-auto h-12 w-12 rounded-full bg-blue-600 flex items-center justify-center text-white font-semibold">
+        <div className="space-y-3 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-full bg-blue-600 text-sm font-semibold text-white">
             JBV
           </div>
           <h1 className="text-2xl font-semibold text-slate-900">JBV Investment Platform</h1>
-          <p className="text-sm text-slate-600">Access your investor dashboard securely with your preferred sign-in method.</p>
+          <p className="text-sm text-slate-600">
+            Enter the email associated with your investor profile to access the limited partner experience.
+          </p>
         </div>
 
         <div className="space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
-          <button
-            type="button"
-            onClick={() => signIn("google", { callbackUrl })}
-            className="w-full inline-flex items-center justify-center rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-slate-700 shadow-sm transition hover:border-blue-600 hover:text-blue-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-          >
-            Sign in with Google
-          </button>
-
-          <div className="relative text-center text-xs uppercase tracking-wide text-slate-400">
-            <span className="bg-white px-2">or</span>
-            <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-slate-200" aria-hidden="true" />
-          </div>
-
-          <form onSubmit={handleEmailSignIn} className="space-y-3">
-            <label className="block text-sm font-medium text-slate-700" htmlFor="email">
-              Email address
-            </label>
-            <input
-              id="email"
-              type="email"
-              required
-              value={email}
-              onChange={(event) => setEmail(event.target.value)}
-              className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-100"
-              placeholder="you@example.com"
-            />
-            <button
-              type="submit"
-              disabled={!email || emailStatus === "sending"}
-              className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition disabled:cursor-not-allowed disabled:bg-blue-300 hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
-            >
-              {emailStatus === "sending" ? "Sending link…" : "Sign in with Email Link"}
-            </button>
-            {emailStatus === "sent" ? (
-              <p className="text-sm text-green-600">Check your inbox for a secure sign-in link.</p>
-            ) : null}
-            {emailStatus === "error" && errorMessage ? (
-              <p className="text-sm text-red-600">{errorMessage}</p>
-            ) : null}
-          </form>
-
-          <div className="relative text-center text-xs uppercase tracking-wide text-slate-400">
-            <span className="bg-white px-2">admin access</span>
-            <div className="absolute inset-x-0 top-1/2 h-px -translate-y-1/2 bg-slate-200" aria-hidden="true" />
-          </div>
-
-          <form onSubmit={handleAdminSignIn} className="space-y-3 pt-1">
-            <div>
-              <label className="block text-sm font-medium text-slate-700" htmlFor="admin-email">
-                Admin email
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2 text-left">
+              <label className="text-sm font-medium text-slate-700" htmlFor="email">
+                Email address
               </label>
               <input
-                id="admin-email"
+                id="email"
                 type="email"
-                value={adminEmail}
-                onChange={(event) => setAdminEmail(event.target.value)}
+                required
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
                 className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-100"
+                placeholder="you@example.com"
                 autoComplete="email"
               />
             </div>
-            <div>
-              <label className="block text-sm font-medium text-slate-700" htmlFor="admin-password">
-                Password
-              </label>
-              <input
-                id="admin-password"
-                type="password"
-                value={adminPassword}
-                onChange={(event) => setAdminPassword(event.target.value)}
-                className="w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-slate-900 shadow-sm focus:border-blue-600 focus:outline-none focus:ring-2 focus:ring-blue-100"
-                autoComplete="current-password"
-              />
-            </div>
             <button
               type="submit"
-              disabled={!adminEmail || !adminPassword || adminStatus === "signing-in"}
-              className="w-full rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white shadow-sm transition disabled:cursor-not-allowed disabled:bg-slate-400 hover:bg-slate-800 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-900"
+              disabled={!email || status === "submitting"}
+              className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition disabled:cursor-not-allowed disabled:bg-blue-300 hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
             >
-              {adminStatus === "signing-in" ? "Signing in…" : "Sign in as Admin"}
+              {status === "submitting" ? "Signing in…" : "Continue"}
             </button>
-            {adminStatus === "error" && adminErrorMessage ? (
-              <p className="text-sm text-red-600">{adminErrorMessage}</p>
-            ) : null}
-            <p className="text-xs text-slate-500">
-              Admin access is limited to authorized JBV team members.
-            </p>
           </form>
+
+          {(errorMessage || queryError) && (
+            <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-600">
+              {errorMessage || queryError}
+            </div>
+          )}
+
+          <p className="text-xs text-slate-500">
+            Need assistance? Contact your JBV relationship manager or email
+            {" "}
+            <a className="font-medium text-blue-600 hover:underline" href="mailto:support@jbv.com">
+              support@jbv.com
+            </a>
+            .
+          </p>
         </div>
       </div>
     </div>

--- a/apps/web/app/lp/head.tsx
+++ b/apps/web/app/lp/head.tsx
@@ -1,0 +1,7 @@
+export default function Head() {
+  return (
+    <>
+      <meta name="robots" content="noindex, nofollow" />
+    </>
+  );
+}

--- a/apps/web/app/lp/investments/[id]/page.tsx
+++ b/apps/web/app/lp/investments/[id]/page.tsx
@@ -31,12 +31,13 @@ interface LpDataResponse {
 
 interface DocumentItem {
   name: string;
-  url: string;
   size?: number;
   type?: string;
   investmentId: string;
   investmentName?: string;
   periodEnding?: any;
+  field: string;
+  index: number;
 }
 
 interface DocumentsResponse {
@@ -300,24 +301,33 @@ export default function InvestmentDetailPage() {
               <p className="text-sm text-slate-500">Latest files associated with this investment.</p>
               <div className="space-y-3">
                 {documents.length ? (
-                  documents.map((doc) => (
-                    <a
-                      key={`${doc.url}-${doc.name}`}
-                      href={doc.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="flex items-center justify-between rounded-xl border border-slate-200 px-4 py-3 text-sm text-blue-700 transition hover:border-blue-400 hover:bg-blue-50"
-                    >
-                      <div>
-                        <p className="font-medium text-slate-900">{doc.name}</p>
-                        <p className="text-xs text-slate-500">
-                          {doc.periodEnding ? `Period Ending: ${formatValue("Period Ending", doc.periodEnding)}` : "Document"}
-                          {doc.size ? ` · ${(doc.size / (1024 * 1024)).toFixed(2)} MB` : ""}
-                        </p>
-                      </div>
-                      <span className="text-xs font-semibold uppercase tracking-wide text-blue-600">Download</span>
-                    </a>
-                  ))
+                  documents.map((doc) => {
+                    const downloadUrl = `/api/lp/documents/download?recordId=${encodeURIComponent(
+                      doc.investmentId
+                    )}&field=${encodeURIComponent(doc.field)}&index=${doc.index}`;
+                    const sizeLabel = doc.size ? `${(doc.size / (1024 * 1024)).toFixed(2)} MB` : null;
+                    const docKey = `${doc.investmentId}-${doc.field}-${doc.index}`;
+                    return (
+                      <a
+                        key={docKey}
+                        href={downloadUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="flex items-center justify-between rounded-xl border border-slate-200 px-4 py-3 text-sm text-blue-700 transition hover:border-blue-400 hover:bg-blue-50"
+                      >
+                        <div>
+                          <p className="font-medium text-slate-900">{doc.name}</p>
+                          <p className="text-xs text-slate-500">
+                            {doc.periodEnding
+                              ? `Period Ending: ${formatValue("Period Ending", doc.periodEnding)}`
+                              : "Document"}
+                            {sizeLabel ? ` · ${sizeLabel}` : ""}
+                          </p>
+                        </div>
+                        <span className="text-xs font-semibold uppercase tracking-wide text-blue-600">Download</span>
+                      </a>
+                    );
+                  })
                 ) : (
                   <div className="rounded-xl border border-dashed border-slate-200 p-8 text-center text-sm text-slate-500">
                     No documents have been shared for this investment yet.

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,12 +1,67 @@
+import Link from "next/link";
+
+const OPTIONS = [
+  {
+    href: "/auth/signin?callbackUrl=/lp",
+    title: "Limited Partner",
+    description: "Portfolio analytics, distributions, and capital account documents.",
+    cta: "Sign in as LP",
+  },
+  {
+    href: "/auth/signin?callbackUrl=/admin",
+    title: "Administrator",
+    description: "Manage visibility, documents, and partner communications.",
+    cta: "Sign in as Admin",
+  },
+];
+
 export default function Home() {
   return (
-    <main className="min-h-screen flex items-center justify-center">
-      <div className="text-center space-y-2">
-        <div className="mx-auto h-10 w-10 rounded bg-[#2563EB]" />
-        <h1 className="text-xl font-semibold">JBV Investment Platform</h1>
-        <p className="text-slate-600">Open <a className="text-[#2563EB] underline" href="/admin">/admin</a> to view the Admin grid.</p>
+    <main className="flex min-h-screen items-center justify-center bg-slate-50 px-6 py-16">
+      <div className="w-full max-w-4xl space-y-10 text-center">
+        <div className="space-y-4">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-blue-600 text-base font-semibold text-white">
+            JBV
+          </div>
+          <h1 className="text-3xl font-semibold text-slate-900">Welcome to the JBV Investment Platform</h1>
+          <p className="text-base text-slate-600">
+            Choose how you would like to access the portal. We&apos;ll guide you through a secure email-only sign in.
+          </p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2">
+          {OPTIONS.map((option) => (
+            <Link
+              key={option.href}
+              href={option.href}
+              className="group flex flex-col justify-between rounded-2xl border border-slate-200 bg-white p-6 text-left shadow-sm transition hover:border-blue-400 hover:shadow-lg"
+            >
+              <div className="space-y-3">
+                <p className="text-sm font-semibold uppercase tracking-[0.18em] text-blue-600">Secure Access</p>
+                <h2 className="text-2xl font-semibold text-slate-900">{option.title}</h2>
+                <p className="text-sm text-slate-600">{option.description}</p>
+              </div>
+              <span className="mt-6 inline-flex items-center text-sm font-semibold text-blue-600 group-hover:translate-x-1 transition">
+                {option.cta}
+                <svg
+                  className="ml-2 h-4 w-4"
+                  viewBox="0 0 16 16"
+                  fill="none"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M5.25 3.75L10.25 8L5.25 12.25"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                  />
+                </svg>
+              </span>
+            </Link>
+          ))}
+        </div>
       </div>
     </main>
   );
 }
-

--- a/apps/web/lib/airtable.ts
+++ b/apps/web/lib/airtable.ts
@@ -3,6 +3,7 @@ import Bottleneck from "bottleneck";
 
 export const PARTNER_INVESTMENTS_TABLE = "Partner Investments";
 export const VISIBILITY_RULES_TABLE = "VisibilityRules";
+export const CONTACTS_TABLE = "Contacts";
 
 export const VIEW_ID = process.env.AIRTABLE_VIEW_ID || undefined;
 
@@ -19,6 +20,8 @@ const LINK_MAP: Record<string, string> = {
 };
 
 const limiter = new Bottleneck({ minTime: 60 });
+
+export const airtableLimiter = limiter;
 
 export type AirtableRecord = Airtable.Record<any>;
 

--- a/apps/web/lib/auth-options.ts
+++ b/apps/web/lib/auth-options.ts
@@ -1,143 +1,51 @@
-import { type NextAuthOptions } from "next-auth";
+import type { NextAuthOptions } from "next-auth";
 import CredentialsProvider from "next-auth/providers/credentials";
-import EmailProvider from "next-auth/providers/email";
-import GoogleProvider from "next-auth/providers/google";
 
-import { getAdminEmails, isAdmin } from "./auth-helpers";
+import { isAdmin, isEmailInAirtableContacts } from "./auth-helpers";
 
-function buildProviders(): NextAuthOptions["providers"] {
-  const providers: NextAuthOptions["providers"] = [];
-  const adminEmails = new Set(getAdminEmails());
-
-  if (process.env.EMAIL_SERVER && process.env.EMAIL_FROM) {
-    providers.push(
-      EmailProvider({
-        server: process.env.EMAIL_SERVER,
-        from: process.env.EMAIL_FROM,
-      })
-    );
-  }
-
-  if (process.env.GOOGLE_CLIENT_ID && process.env.GOOGLE_CLIENT_SECRET) {
-    providers.push(
-      GoogleProvider({
-        clientId: process.env.GOOGLE_CLIENT_ID,
-        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-      })
-    );
-  }
-
-  if (providers.length === 0) {
-    const allowedEmails = new Set(adminEmails);
-    const devEmails = (process.env.DEV_LOGIN_EMAILS || "")
-      .split(",")
-      .map((entry) => entry.trim().toLowerCase())
-      .filter(Boolean);
-    for (const email of devEmails) {
-      allowedEmails.add(email);
-    }
-
-    console.warn(
-      "[auth] No authentication providers configured. Falling back to in-memory development login restricted to:",
-      Array.from(allowedEmails)
-    );
-
-    providers.push(
-      CredentialsProvider({
-        id: "email",
-        name: "Development Email",
-        credentials: {
-          email: {
-            label: "Email",
-            type: "email",
-            placeholder: "you@example.com",
-          },
-        },
-        async authorize(credentials) {
-          const email = credentials?.email;
-          if (!email || typeof email !== "string") {
-            return null;
-          }
-
-          const normalizedEmail = email.trim().toLowerCase();
-          if (!normalizedEmail) {
-            return null;
-          }
-
-          if (allowedEmails.size > 0 && !allowedEmails.has(normalizedEmail)) {
-            console.warn(`[auth] Development login rejected for unauthorized email: ${normalizedEmail}`);
-            return null;
-          }
-
-          return {
-            id: normalizedEmail,
-            email: normalizedEmail,
-            name: normalizedEmail,
-          };
-        },
-      })
-    );
-  }
-
-  providers.push(
+export const authOptions: NextAuthOptions = {
+  providers: [
     CredentialsProvider({
-      id: "admin-login",
-      name: "Admin Password",
+      name: "Email",
       credentials: {
         email: {
           label: "Email",
           type: "email",
-          placeholder: "jb@jbv.com",
-        },
-        password: {
-          label: "Password",
-          type: "password",
-          placeholder: "Enter password",
+          placeholder: "you@example.com",
         },
       },
       async authorize(credentials) {
         const email = credentials?.email;
-        const password = credentials?.password;
-
-        if (!email || typeof email !== "string" || !password || typeof password !== "string") {
+        if (!email || typeof email !== "string") {
           return null;
         }
 
         const normalizedEmail = email.trim().toLowerCase();
-        const normalizedPassword = password.trim();
-
-        if (!adminEmails.has(normalizedEmail)) {
+        if (!normalizedEmail) {
           return null;
         }
 
-        const expectedPassword = process.env.ADMIN_LOGIN_PASSWORD || "admin123";
-
-        if (normalizedPassword !== expectedPassword) {
+        const exists = await isEmailInAirtableContacts(normalizedEmail);
+        if (!exists) {
           return null;
         }
 
         return {
           id: normalizedEmail,
           email: normalizedEmail,
-          name: "JBV Admin",
-          role: "admin",
         };
       },
-    })
-  );
-
-  return providers;
-}
-
-export const authOptions: NextAuthOptions = {
-  providers: buildProviders(),
-  secret: process.env.NEXTAUTH_SECRET || "development-secret",
+    }),
+  ],
   pages: {
     signIn: "/auth/signin",
   },
+  secret: process.env.NEXTAUTH_SECRET || "development-secret",
   callbacks: {
     async jwt({ token }) {
-      token.role = isAdmin(token.email) ? "admin" : "lp";
+      if (typeof token.email === "string") {
+        token.role = isAdmin(token.email) ? "admin" : "lp";
+      }
       return token;
     },
     async session({ session, token }) {

--- a/apps/web/lib/lp-server.ts
+++ b/apps/web/lib/lp-server.ts
@@ -156,12 +156,15 @@ function parseNumber(value: any) {
 
 function findFieldKey(records: ExpandedRecord[], candidates: string[]) {
   if (!records.length) return undefined;
-  const normalizedCandidates = new Set(candidates.map((name) => normalizeFieldKey(name)));
-  for (const record of records) {
-    const fields = record.fields || {};
-    for (const key of Object.keys(fields)) {
-      if (normalizedCandidates.has(normalizeFieldKey(key))) {
-        return key;
+  const normalizedCandidates = candidates.map((name) => normalizeFieldKey(name));
+  for (const normalizedCandidate of normalizedCandidates) {
+    if (!normalizedCandidate) continue;
+    for (const record of records) {
+      const fields = record.fields || {};
+      for (const key of Object.keys(fields)) {
+        if (normalizeFieldKey(key) === normalizedCandidate) {
+          return key;
+        }
       }
     }
   }
@@ -170,7 +173,8 @@ function findFieldKey(records: ExpandedRecord[], candidates: string[]) {
 
 export function computeMetrics(records: ExpandedRecord[]) {
   const commitmentKey = findFieldKey(records, ["Commitment"]);
-  const navKey = findFieldKey(records, ["Total NAV", "Current NAV"]);
+  const totalNavKey = findFieldKey(records, ["Total NAV"]);
+  const currentNavKey = findFieldKey(records, ["Current NAV"]);
   const distributionsKey = findFieldKey(records, ["Distributions"]);
   const netMoicKey = findFieldKey(records, ["Net MOIC", "MOIC"]);
 
@@ -188,8 +192,11 @@ export function computeMetrics(records: ExpandedRecord[]) {
       if (value !== null) commitmentTotal += value;
     }
 
-    if (navKey && Object.prototype.hasOwnProperty.call(fields, navKey)) {
-      const value = parseNumber(fields[navKey]);
+    if (totalNavKey && Object.prototype.hasOwnProperty.call(fields, totalNavKey)) {
+      const value = parseNumber(fields[totalNavKey]);
+      if (value !== null) navTotal += value;
+    } else if (currentNavKey && Object.prototype.hasOwnProperty.call(fields, currentNavKey)) {
+      const value = parseNumber(fields[currentNavKey]);
       if (value !== null) navTotal += value;
     }
 


### PR DESCRIPTION
## Summary
- replace the landing experience with an entry point that lets visitors choose LP or admin access before redirecting into the email-only sign-in flow
- configure NextAuth with an Airtable-verified credentials provider and update the sign-in UI plus helper utilities, including Total NAV fallbacks and noindex directives for LP/admin routes
- harden LP documents by filtering attachment metadata, proxying downloads through a secure API, and updating dashboard/detail views to group files by investment period and link through the proxy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cae92ccbc883208a12d858542ec888