### PR TITLE
Avoid importing Airtable server module in LP pages

### DIFF
--- a/apps/web/app/lp/investments/[id]/page.tsx
+++ b/apps/web/app/lp/investments/[id]/page.tsx
@@ -12,9 +12,8 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import type { ExpandedRecord } from "@/lib/airtable";
+import { normalizeFieldKey, type ExpandedRecord } from "@/lib/airtable-shared";
 import { formatCurrencyUSD, formatDate, formatNumber } from "@/lib/format";
-import { normalizeFieldKey } from "@/lib/airtable";
 import { usePolling, type RefreshStatus } from "@/hooks/usePolling";
 
 interface Metrics {

--- a/apps/web/app/lp/investments/page.tsx
+++ b/apps/web/app/lp/investments/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { ExpandedRecord } from "@/lib/airtable";
+import { normalizeFieldKey, type ExpandedRecord } from "@/lib/airtable-shared";
 import { formatCurrencyUSD, formatDate, formatNumber, formatPercent } from "@/lib/format";
-import { normalizeFieldKey } from "@/lib/airtable";
 import { usePolling, type RefreshStatus } from "@/hooks/usePolling";
 
 interface Metrics {

--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -12,10 +12,9 @@ import {
   BarChart,
   Bar,
 } from "recharts";
-import type { ExpandedRecord } from "@/lib/airtable";
+import { normalizeFieldKey, type ExpandedRecord } from "@/lib/airtable-shared";
 import { formatCurrencyUSD, formatDate, formatNumber } from "@/lib/format";
 import { usePolling, type RefreshStatus } from "@/hooks/usePolling";
-import { normalizeFieldKey } from "@/lib/airtable";
 
 interface Metrics {
   commitmentTotal: number;

--- a/apps/web/lib/airtable-shared.ts
+++ b/apps/web/lib/airtable-shared.ts
@@ -1,0 +1,15 @@
+export type LinkedRecord = {
+  id: string;
+  fields: Record<string, any>;
+  displayName: any;
+};
+
+export type ExpandedRecord = {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime: string | null;
+};
+
+export function normalizeFieldKey(name: string) {
+  return (name || "").trim().toLowerCase();
+}

--- a/apps/web/lib/airtable.ts
+++ b/apps/web/lib/airtable.ts
@@ -1,5 +1,7 @@
 import Airtable from "airtable";
 import Bottleneck from "bottleneck";
+import { normalizeFieldKey } from "./airtable-shared";
+import type { ExpandedRecord, LinkedRecord } from "./airtable-shared";
 
 export const PARTNER_INVESTMENTS_TABLE = "Partner Investments";
 export const VISIBILITY_RULES_TABLE = "VisibilityRules";
@@ -24,18 +26,6 @@ const limiter = new Bottleneck({ minTime: 60 });
 export const airtableLimiter = limiter;
 
 export type AirtableRecord = Airtable.Record<any>;
-
-export type LinkedRecord = {
-  id: string;
-  fields: Record<string, any>;
-  displayName: any;
-};
-
-export type ExpandedRecord = {
-  id: string;
-  fields: Record<string, any>;
-  _updatedTime: string | null;
-};
 
 const CHUNK_SIZE = 50;
 
@@ -130,6 +120,5 @@ export async function selectAllRecords(
     .all();
 }
 
-export function normalizeFieldKey(name: string) {
-  return (name || "").trim().toLowerCase();
-}
+export { normalizeFieldKey } from "./airtable-shared";
+export type { ExpandedRecord, LinkedRecord } from "./airtable-shared";


### PR DESCRIPTION
## Summary
- create a shared Airtable helper module that only exposes typings and key normalization for client consumers
- update the Airtable server utilities to reuse the shared helpers and keep the API client code server-only
- switch LP dashboard and investment pages to the shared helpers so the LP experience no longer loads the Airtable client bundle and goes blank after login

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68caf71ae6448320a54878acce42147f