### PR TITLE
Improve LP data scoping and UI

### DIFF
--- a/apps/web/app/api/lp/data/route.ts
+++ b/apps/web/app/api/lp/data/route.ts
@@ -1,9 +1,18 @@
 import { getSession } from "@/lib/auth";
 import { type Role } from "@/lib/auth-helpers";
-import { computeMetrics, loadPartnerInvestmentRecords } from "@/lib/lp-server";
+import {
+  applyVisibility,
+  computeMetrics,
+  contactDisplayName,
+  expandLinked,
+  findContactsByEmail,
+  getInvestmentsForContactIds,
+} from "@/lib/lp-server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+const VIEW_ID = process.env.AIRTABLE_VIEW_ID;
 
 export async function GET() {
   try {
@@ -15,11 +24,41 @@ export async function GET() {
     }
 
     const role = (user.role as Role | undefined) ?? "lp";
-    const { records } = await loadPartnerInvestmentRecords(email, role);
-    const metrics = computeMetrics(records);
+    const contacts = await findContactsByEmail(email);
+    const contactIds = contacts.map((c) => c.id);
 
-    return Response.json({ records, metrics });
+    let note: string | undefined;
+    if (!contactIds.length) {
+      note = "contact-not-found";
+    }
+
+    let investments = [] as Awaited<ReturnType<typeof getInvestmentsForContactIds>>;
+    if (contactIds.length) {
+      investments = await getInvestmentsForContactIds(contactIds, VIEW_ID);
+      if (!investments.length && VIEW_ID) {
+        note = "view-filtered";
+      }
+    }
+
+    const expanded = await Promise.all(investments.map((record) => expandLinked(record)));
+    const visible = await Promise.all(
+      expanded.map(async (record) => ({
+        ...record,
+        fields: await applyVisibility(record.fields, role),
+      }))
+    );
+
+    const metrics = computeMetrics(visible);
+    const profileName = contacts.length ? contactDisplayName(contacts[0]) : email;
+
+    return Response.json({
+      profile: { name: profileName, email },
+      records: visible,
+      metrics,
+      note,
+    });
   } catch (error: any) {
+    console.error("[lp-data] Failed to load LP data", error);
     return Response.json({ error: error?.message || "Failed to load data" }, { status: 500 });
   }
 }

--- a/apps/web/app/api/lp/documents/download/route.ts
+++ b/apps/web/app/api/lp/documents/download/route.ts
@@ -1,10 +1,15 @@
 import { getSession } from "@/lib/auth";
 import { type Role } from "@/lib/auth-helpers";
-import { PARTNER_INVESTMENTS_TABLE, base } from "@/lib/airtable";
-import { loadPartnerInvestmentRecords } from "@/lib/lp-server";
+import {
+  applyVisibility,
+  findContactsByEmail,
+  getInvestmentsForContactIds,
+} from "@/lib/lp-server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+const VIEW_ID = process.env.AIRTABLE_VIEW_ID;
 
 function parseIndex(value: string | null): number {
   if (!value) return 0;
@@ -31,32 +36,36 @@ export async function GET(request: Request) {
     }
 
     const role = (user.role as Role | undefined) ?? "lp";
-    const { records } = await loadPartnerInvestmentRecords(email, role);
-    const record = records.find((item) => item.id === recordId);
+    const contacts = await findContactsByEmail(email);
+    const contactIds = contacts.map((c) => c.id);
+    if (!contactIds.length) {
+      return new Response("Not found", { status: 404 });
+    }
+
+    const investments = await getInvestmentsForContactIds(contactIds, VIEW_ID);
+    const record = investments.find((item) => item.id === recordId);
     if (!record) {
       return new Response("Not found", { status: 404 });
     }
 
-    const visibleFields = record.fields || {};
+    const visibleFields = await applyVisibility(record.fields, role);
     if (!Object.prototype.hasOwnProperty.call(visibleFields, field)) {
       return new Response("Not found", { status: 404 });
     }
 
-    const airtableRecord = await base(PARTNER_INVESTMENTS_TABLE).find(recordId);
-    const rawField = (airtableRecord.fields || {})[field as keyof typeof airtableRecord.fields];
-
-    if (!Array.isArray(rawField) || rawField.length === 0) {
+    const value = visibleFields[field as keyof typeof visibleFields];
+    if (!Array.isArray(value) || value.length <= index) {
       return new Response("File not found", { status: 404 });
     }
 
-    const attachment = rawField[index];
+    const attachment = value[index];
     if (!attachment || typeof attachment.url !== "string") {
       return new Response("File not found", { status: 404 });
     }
 
     return Response.redirect(attachment.url, 302);
   } catch (error) {
-    console.error("[documents] Failed to proxy download", error);
+    console.error("[documents-download] Failed to proxy download", error);
     return new Response("Unable to download document", { status: 500 });
   }
 }

--- a/apps/web/app/api/lp/documents/route.ts
+++ b/apps/web/app/api/lp/documents/route.ts
@@ -1,9 +1,16 @@
 import { getSession } from "@/lib/auth";
 import { type Role } from "@/lib/auth-helpers";
-import { loadPartnerInvestmentRecords } from "@/lib/lp-server";
+import {
+  applyVisibility,
+  expandLinked,
+  findContactsByEmail,
+  getInvestmentsForContactIds,
+} from "@/lib/lp-server";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
+
+const VIEW_ID = process.env.AIRTABLE_VIEW_ID;
 
 type Attachment = {
   name?: string;
@@ -11,6 +18,20 @@ type Attachment = {
   size?: number;
   type?: string;
   filename?: string;
+};
+
+type DocumentsResponse = {
+  documents: Array<{
+    name: string;
+    size?: number;
+    type?: string;
+    investmentId: string;
+    investmentName?: string;
+    periodEnding?: any;
+    field: string;
+    index: number;
+  }>;
+  note?: string;
 };
 
 function isAttachment(value: any): value is Attachment {
@@ -22,6 +43,9 @@ function resolveInvestmentName(fields: Record<string, any>) {
   for (const key of preferredKeys) {
     if (Object.prototype.hasOwnProperty.call(fields, key)) {
       const value = fields[key];
+      if (Array.isArray(value) && value[0] && typeof value[0] === "object" && "displayName" in value[0]) {
+        return value[0].displayName as string;
+      }
       if (typeof value === "string" && value.trim()) return value;
     }
   }
@@ -48,20 +72,32 @@ export async function GET() {
     }
 
     const role = (user.role as Role | undefined) ?? "lp";
-    const { records } = await loadPartnerInvestmentRecords(email, role);
+    const contacts = await findContactsByEmail(email);
+    const contactIds = contacts.map((c) => c.id);
 
-    const documents: Array<{
-      name: string;
-      size?: number;
-      type?: string;
-      investmentId: string;
-      investmentName?: string;
-      periodEnding?: any;
-      field: string;
-      index: number;
-    }> = [];
+    let note: DocumentsResponse["note"];
+    if (!contactIds.length) {
+      note = "contact-not-found";
+      const payload: DocumentsResponse = { documents: [], note };
+      return Response.json(payload);
+    }
 
-    for (const record of records) {
+    const investments = await getInvestmentsForContactIds(contactIds, VIEW_ID);
+    if (!investments.length && VIEW_ID) {
+      note = "view-filtered";
+    }
+
+    const expanded = await Promise.all(investments.map((record) => expandLinked(record)));
+    const visible = await Promise.all(
+      expanded.map(async (record) => ({
+        ...record,
+        fields: await applyVisibility(record.fields, role),
+      }))
+    );
+
+    const documents: DocumentsResponse["documents"] = [];
+
+    for (const record of visible) {
       const fields = record.fields || {};
       const investmentName = resolveInvestmentName(fields);
       const periodEnding = resolvePeriodEnding(fields);
@@ -85,8 +121,10 @@ export async function GET() {
       }
     }
 
-    return Response.json({ documents });
+    const payload: DocumentsResponse = { documents, note };
+    return Response.json(payload);
   } catch (error: any) {
+    console.error("[lp-documents] Failed to load documents", error);
     return Response.json({ error: error?.message || "Failed to load documents" }, { status: 500 });
   }
 }

--- a/apps/web/app/lp/docs/page.tsx
+++ b/apps/web/app/lp/docs/page.tsx
@@ -17,6 +17,7 @@ interface DocumentItem {
 
 interface DocumentsResponse {
   documents: DocumentItem[];
+  note?: string;
 }
 
 function buildStatusBadge(status: RefreshStatus, lastUpdated: Date | null) {
@@ -71,6 +72,16 @@ function getPeriodSortValue(value: any) {
 
 export default function DocumentsPage() {
   const { data, status, error, initialized, lastUpdated } = usePolling<DocumentsResponse>("/api/lp/documents");
+  const note = data?.note;
+  const noteMessage = useMemo(() => {
+    if (note === "contact-not-found") {
+      return "We couldn’t locate a matching Contact record for your login email. Please reach out to the investor relations team to confirm your access.";
+    }
+    if (note === "view-filtered") {
+      return "Your Airtable view is currently filtering the investment rows tied to your documents. Adjust the view or contact an administrator if this is unexpected.";
+    }
+    return null;
+  }, [note]);
 
   const grouped = useMemo(() => {
     const sections = new Map<
@@ -125,9 +136,15 @@ export default function DocumentsPage() {
         </div>
       ) : null}
 
+      {initialized && noteMessage && status !== "error" ? (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+          {noteMessage}
+        </div>
+      ) : null}
+
       {!initialized ? (
         <div className="h-64 animate-pulse rounded-2xl bg-gradient-to-br from-slate-200/80 to-slate-100" />
-      ) : !grouped.length ? (
+      ) : !grouped.length && status !== "error" ? (
         <div className="rounded-2xl border border-dashed border-slate-200 p-10 text-center text-sm text-slate-500">
           Documents shared with your investments will surface here automatically.
         </div>

--- a/apps/web/app/lp/investments/page.tsx
+++ b/apps/web/app/lp/investments/page.tsx
@@ -12,9 +12,16 @@ interface Metrics {
   netMoicAvg: number;
 }
 
+interface Profile {
+  name: string;
+  email: string;
+}
+
 interface LpDataResponse {
   records: ExpandedRecord[];
   metrics: Metrics;
+  profile: Profile;
+  note?: string;
 }
 
 function parseNumber(value: any) {
@@ -139,6 +146,16 @@ export default function LPInvestmentsPage() {
   const [search, setSearch] = useState("");
 
   const records = useMemo(() => data?.records ?? [], [data?.records]);
+  const note = data?.note;
+  const noteMessage = useMemo(() => {
+    if (note === "contact-not-found") {
+      return "We couldn’t locate a matching Contact record for your login email. Please reach out to the investor relations team to confirm your access.";
+    }
+    if (note === "view-filtered") {
+      return "Your Airtable view is currently filtering out investment rows. Adjust the view or contact an administrator if you believe this is unexpected.";
+    }
+    return null;
+  }, [note]);
 
   const columnKeys = useMemo(() => {
     if (!records.length) return [] as string[];
@@ -238,9 +255,15 @@ export default function LPInvestmentsPage() {
         </div>
       ) : null}
 
+      {initialized && noteMessage && status !== "error" ? (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-700">
+          {noteMessage}
+        </div>
+      ) : null}
+
       {!initialized ? (
         <div className="h-64 animate-pulse rounded-2xl bg-gradient-to-br from-slate-200/80 to-slate-100" />
-      ) : filteredRecords.length === 0 ? (
+      ) : filteredRecords.length === 0 && status !== "error" ? (
         <div className="rounded-2xl border border-dashed border-slate-200 p-10 text-center text-sm text-slate-500">
           No investments match your current filters.
         </div>

--- a/apps/web/app/lp/layout.tsx
+++ b/apps/web/app/lp/layout.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import type { ReactNode } from "react";
+import { useEffect, useMemo, useState, type ReactNode } from "react";
 
 const NAV_ITEMS = [
   { href: "/lp", label: "Overview" },
@@ -11,8 +11,74 @@ const NAV_ITEMS = [
   { href: "/lp/help", label: "Help" },
 ];
 
+type Profile = {
+  name: string;
+  email: string;
+};
+
 export default function LPLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const loadProfile = async () => {
+      try {
+        const response = await fetch("/api/lp/data", {
+          cache: "no-store",
+          credentials: "same-origin",
+        });
+        if (!response.ok) {
+          throw new Error(`Request failed with status ${response.status}`);
+        }
+        const payload = (await response.json()) as { profile?: Profile | null };
+        if (!isMounted) return;
+        setProfile(payload.profile ?? null);
+        setError(false);
+      } catch (err) {
+        if (!isMounted) return;
+        setError(true);
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    };
+
+    loadProfile();
+
+    const handleFocus = () => {
+      loadProfile();
+    };
+
+    window.addEventListener("focus", handleFocus);
+    return () => {
+      isMounted = false;
+      window.removeEventListener("focus", handleFocus);
+    };
+  }, []);
+
+  const initials = useMemo(() => {
+    const name = profile?.name?.trim();
+    if (!name) return "LP";
+    const parts = name.split(/\s+/).filter(Boolean);
+    if (!parts.length) return name.slice(0, 2).toUpperCase();
+    const first = parts[0]?.[0] ?? "";
+    const last = parts.length > 1 ? parts[parts.length - 1]?.[0] ?? "" : "";
+    const combo = `${first}${last}`.toUpperCase();
+    return combo || name.slice(0, 2).toUpperCase();
+  }, [profile?.name]);
+
+  const status = useMemo(() => {
+    if (profile) {
+      return { label: "Secure session active", tone: "text-emerald-600", dot: "bg-emerald-500" };
+    }
+    if (error) {
+      return { label: "Session connection issue", tone: "text-red-600", dot: "bg-red-500" };
+    }
+    return { label: "Connecting…", tone: "text-slate-500", dot: "bg-slate-300" };
+  }, [profile, error]);
 
   return (
     <div className="min-h-screen bg-slate-50">
@@ -26,9 +92,20 @@ export default function LPLayout({ children }: { children: ReactNode }) {
                 Insights, performance, and documents tailored to your investments.
               </p>
             </div>
-            <div className="flex items-center gap-3 text-sm text-slate-500">
-              <div className="h-2 w-2 rounded-full bg-emerald-500" aria-hidden="true" />
-              Secure session active
+            <div className="flex items-center gap-3 rounded-full border border-slate-200 bg-white px-4 py-2 shadow-sm">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-sm font-semibold text-white">
+                {initials}
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm font-semibold text-slate-900">
+                  {profile?.name || (loading ? "Loading investor" : "Investor")}
+                </span>
+                <span className="text-xs text-slate-500">{profile?.email || (error ? "Unavailable" : "")}</span>
+              </div>
+              <div className={`flex items-center gap-2 text-xs font-medium ${status.tone}`}>
+                <span className={`h-2 w-2 rounded-full ${status.dot}`} aria-hidden="true" />
+                {status.label}
+              </div>
             </div>
           </div>
           <nav className="mt-6 flex flex-wrap gap-2 text-sm font-medium">


### PR DESCRIPTION
## Summary
- Harden Airtable access for LPs with helper utilities that normalize emails, expand linked records, apply visibility rules, and compute resilient numeric metrics. 【F:apps/web/lib/lp-server.ts†L5-L263】
- Update LP data and document APIs to derive investments through Contacts, surface profile diagnostics, and gate attachment downloads with visibility-aware checks. 【F:apps/web/app/api/lp/data/route.ts†L1-L63】【F:apps/web/app/api/lp/documents/route.ts†L1-L125】【F:apps/web/app/api/lp/documents/download/route.ts†L1-L67】
- Refresh LP screens with a profile chip, reliable metrics and charts, diagnostic messaging, and empty states that only appear once filtered records are truly empty. 【F:apps/web/app/lp/layout.tsx†L1-L133】【F:apps/web/app/lp/page.tsx†L1-L429】【F:apps/web/app/lp/investments/page.tsx†L1-L325】【F:apps/web/app/lp/docs/page.tsx†L1-L200】

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cb014f244083208326a2916e578ec6