### PR TITLE
Add bulk column visibility toggles and update contact email

### DIFF
--- a/apps/web/app/auth/signin/page.tsx
+++ b/apps/web/app/auth/signin/page.tsx
@@ -116,8 +116,8 @@ function SignInForm() {
           <p className="text-xs text-slate-500">
             Need assistance? Contact your JBV relationship manager or email
             {" "}
-            <a className="font-medium text-blue-600 hover:underline" href="mailto:support@jbv.com">
-              support@jbv.com
+            <a className="font-medium text-blue-600 hover:underline" href="mailto:jb@JBV.com">
+              jb@JBV.com
             </a>
             .
           </p>

--- a/apps/web/app/lp/help/page.tsx
+++ b/apps/web/app/lp/help/page.tsx
@@ -4,8 +4,8 @@ export default function HelpPage() {
       <h2 className="text-2xl font-semibold text-slate-900">Help & Resources</h2>
       <p className="text-sm text-slate-600">
         Looking for assistance? Your dedicated JBV team is ready to help. Reach out to your relationship manager or email
-        <a href="mailto:support@jbv.com" className="text-blue-600 hover:underline">
-          support@jbv.com
+        <a href="mailto:jb@JBV.com" className="text-blue-600 hover:underline">
+          jb@JBV.com
         </a>
         .
       </p>

--- a/apps/web/components/admin/ColumnManager.tsx
+++ b/apps/web/components/admin/ColumnManager.tsx
@@ -95,6 +95,8 @@ export default function ColumnManager({
     return map;
   }, [columns]);
 
+  const allColumnIds = useMemo(() => columns.map((col) => col.normalizedId), [columns]);
+
   const hiddenSet = useMemo(() => new Set(layout.hidden || []), [layout.hidden]);
 
   const orderedIds = useMemo(() => layout.order.filter((id) => columnMap.has(id)), [layout.order, columnMap]);
@@ -121,6 +123,16 @@ export default function ColumnManager({
   };
 
   const makeRuleKey = (normalizedId: string) => `${tableId}:${normalizedId}`;
+
+  const handleToggleAll = (visible: boolean) => {
+    const nextHidden = new Set(layout.hidden || []);
+    if (visible) {
+      for (const id of allColumnIds) nextHidden.delete(id);
+    } else {
+      for (const id of allColumnIds) nextHidden.add(id);
+    }
+    onLayoutChange({ order: layout.order, hidden: Array.from(nextHidden) });
+  };
 
   const handleRuleToggle = async (normalizedId: string, which: "lp" | "partners", value: boolean) => {
     const key = makeRuleKey(normalizedId);
@@ -154,10 +166,26 @@ export default function ColumnManager({
         <div className="fixed inset-0 z-40">
           <div className="absolute inset-0 bg-black/30" onClick={() => setOpen(false)} />
           <aside className="absolute right-0 top-0 flex h-full w-full max-w-xl flex-col bg-white shadow-2xl">
-            <header className="flex items-center justify-between border-b px-5 py-4">
-              <div>
+            <header className="flex flex-wrap items-center justify-between gap-4 border-b px-5 py-4">
+              <div className="flex flex-col gap-2">
                 <h2 className="text-base font-semibold text-slate-900">Manage Columns</h2>
                 <p className="text-sm text-slate-500">Arrange local columns and adjust LP/Partner visibility.</p>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    className="rounded border px-3 py-1 text-xs font-medium text-slate-700 transition hover:bg-slate-50"
+                    onClick={() => handleToggleAll(true)}
+                  >
+                    Check all
+                  </button>
+                  <button
+                    type="button"
+                    className="rounded border px-3 py-1 text-xs font-medium text-slate-700 transition hover:bg-slate-50"
+                    onClick={() => handleToggleAll(false)}
+                  >
+                    Uncheck all
+                  </button>
+                </div>
               </div>
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- add bulk check/uncheck controls to the Manage Columns admin modal so admins can toggle all columns at once
- update public support email references to jb@JBV.com across the web app

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_b_68cb0c432b948320b149489f0972ba83