### PR TITLE
Add LP investment summary tab with server API and CSV export

### DIFF
--- a/apps/web/app/api/lp/summary/route.ts
+++ b/apps/web/app/api/lp/summary/route.ts
@@ -1,0 +1,210 @@
+import { getSession } from "@/lib/auth";
+import { type Role } from "@/lib/auth-helpers";
+import {
+  applyVisibility,
+  expandLinked,
+  findContactsByEmail,
+  getInvestmentsForContactIds,
+} from "@/lib/lp-server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const VIEW_ID = process.env.AIRTABLE_VIEW_ID;
+
+const RECOMMENDED_FIELDS = [
+  "Partner Investment",
+  "Partner",
+  "Fund",
+  "Status",
+  "Commitment",
+  "Contributed / Total LP Commitment",
+  "Current NAV",
+  "Total NAV",
+  "Distributions",
+  "Gain / Loss",
+  "Net MOIC",
+  "FMV / Share",
+  "Cost / Share",
+  "Paid Dates",
+  "Period Ending",
+  "Vintage",
+  "Investment Year (K-1 Formula)",
+  "Target Securities",
+  "Subscription Doc",
+  "Latest PCAP File",
+  "PCAP Distribution Report",
+  "Calculation",
+  "Status (I)",
+  "SubDoc Name",
+  "PRIMARY CONTACT",
+  "Primary Contact",
+] as const;
+
+const LINKED_FIELD_NAMES = new Set([
+  "Partner",
+  "Fund",
+  "Target Securities",
+  "Primary Contact",
+  "PRIMARY CONTACT",
+]);
+
+type SummaryRecord = {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime: string | null;
+};
+
+type SummaryResponse = {
+  fieldOrder: string[];
+  records: SummaryRecord[];
+};
+
+type LinkedValue = { id: string; displayName: string };
+
+type AttachmentValue = {
+  url?: string;
+  name?: string;
+  filename?: string;
+  type?: string;
+  size?: number;
+};
+
+function sanitizeLinkedValues(value: any[]): LinkedValue[] {
+  return value
+    .map((entry, index) => {
+      if (!entry) return null;
+      if (typeof entry === "string") {
+        return { id: entry, displayName: entry };
+      }
+      if (typeof entry === "object") {
+        const id = typeof entry.id === "string" ? entry.id : String(index);
+        const displayName =
+          (typeof entry.displayName === "string" && entry.displayName) ||
+          (typeof entry.name === "string" && entry.name) ||
+          (entry.fields &&
+            (entry.fields["Name"] ||
+              entry.fields["Full Name"] ||
+              entry.fields["Company"] ||
+              entry.fields["Email"])) ||
+          id;
+        return { id, displayName };
+      }
+      return null;
+    })
+    .filter((item): item is LinkedValue => Boolean(item));
+}
+
+function sanitizeAttachmentValues(value: any[]): AttachmentValue[] {
+  return value
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return null;
+      if (typeof entry.url !== "string") return null;
+      return {
+        url: entry.url,
+        name: typeof entry.name === "string" ? entry.name : undefined,
+        filename: typeof entry.filename === "string" ? entry.filename : undefined,
+        type: typeof entry.type === "string" ? entry.type : undefined,
+        size: typeof entry.size === "number" ? entry.size : undefined,
+      };
+    })
+    .filter((item): item is AttachmentValue => Boolean(item));
+}
+
+function sanitizeFields(fields: Record<string, any>): Record<string, any> {
+  const sanitized: Record<string, any> = {};
+  for (const [key, value] of Object.entries(fields || {})) {
+    if (value === undefined) continue;
+    if (Array.isArray(value)) {
+      if (LINKED_FIELD_NAMES.has(key)) {
+        sanitized[key] = sanitizeLinkedValues(value);
+        continue;
+      }
+      if (value.length && value.every((entry) => entry && typeof entry === "object" && "url" in entry)) {
+        sanitized[key] = sanitizeAttachmentValues(value);
+        continue;
+      }
+      sanitized[key] = value.slice();
+      continue;
+    }
+    sanitized[key] = value;
+  }
+  return sanitized;
+}
+
+function buildFieldOrder(records: SummaryRecord[]): string[] {
+  const fieldNames = new Set<string>();
+  for (const record of records) {
+    Object.keys(record.fields || {}).forEach((key) => {
+      fieldNames.add(key);
+    });
+  }
+
+  const seen = new Set<string>();
+  const curated: string[] = [];
+  for (const field of RECOMMENDED_FIELDS) {
+    if (fieldNames.has(field) && !seen.has(field)) {
+      curated.push(field);
+      seen.add(field);
+    }
+  }
+
+  const extras = Array.from(fieldNames)
+    .filter((field) => !seen.has(field))
+    .sort((a, b) => a.localeCompare(b));
+
+  return [...curated, ...extras];
+}
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    const user = session?.user;
+    const email = user?.email;
+    if (!session || !user || !email) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const role = (user.role as Role | undefined) ?? "lp";
+    const contacts = await findContactsByEmail(email);
+    if (!contacts.length) {
+      const payload: SummaryResponse = { fieldOrder: [], records: [] };
+      return Response.json(payload);
+    }
+
+    const contactIds = contacts.map((contact) => contact.id);
+    const investments = await getInvestmentsForContactIds(contactIds, VIEW_ID);
+
+    if (!investments.length) {
+      const payload: SummaryResponse = { fieldOrder: [], records: [] };
+      return Response.json(payload);
+    }
+
+    const processed = await Promise.all(
+      investments.map(async (record) => {
+        const expanded = await expandLinked(record);
+        const visibleFields = await applyVisibility(expanded.fields, role);
+        const sanitizedFields = sanitizeFields(visibleFields);
+        return {
+          id: expanded.id,
+          fields: sanitizedFields,
+          _updatedTime: expanded._updatedTime ?? null,
+        } satisfies SummaryRecord;
+      })
+    );
+
+    const filteredRecords = processed.filter((record) => Object.keys(record.fields).length > 0);
+
+    if (!filteredRecords.length) {
+      const payload: SummaryResponse = { fieldOrder: [], records: [] };
+      return Response.json(payload);
+    }
+
+    const fieldOrder = buildFieldOrder(filteredRecords);
+    const payload: SummaryResponse = { fieldOrder, records: filteredRecords };
+    return Response.json(payload);
+  } catch (error) {
+    console.error("[lp-summary] Failed to load LP summary", error);
+    return Response.json({ error: "Failed to load summary" }, { status: 500 });
+  }
+}

--- a/apps/web/app/lp/layout.tsx
+++ b/apps/web/app/lp/layout.tsx
@@ -9,6 +9,7 @@ const NAV_ITEMS = [
   { href: "/lp/investments", label: "Investments" },
   { href: "/lp/docs", label: "Documents" },
   { href: "/lp/help", label: "Help" },
+  { href: "/lp/summary", label: "Investment Summary" },
 ];
 
 type Profile = {

--- a/apps/web/app/lp/summary/page.tsx
+++ b/apps/web/app/lp/summary/page.tsx
@@ -1,0 +1,262 @@
+"use client";
+
+import { useCallback } from "react";
+import { normalizeFieldKey } from "@/lib/airtable-shared";
+import { formatCurrencyUSD, formatDate, formatNumber, formatPercent } from "@/lib/format";
+import { usePolling, type RefreshStatus } from "@/hooks/usePolling";
+import { toCsv, type SummaryResponse } from "@/lib/csv";
+
+type LinkedValue = { id: string; displayName?: string };
+
+type AttachmentValue = { url?: string; name?: string; filename?: string; type?: string };
+
+function buildStatusBadge(status: RefreshStatus, lastUpdated: Date | null) {
+  const label =
+    status === "refreshing" ? "Refreshing" : status === "error" ? "Error" : "Idle";
+  const tone =
+    status === "refreshing"
+      ? "bg-blue-50 text-blue-600"
+      : status === "error"
+      ? "bg-red-50 text-red-600"
+      : "bg-emerald-50 text-emerald-600";
+
+  return (
+    <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${tone}`}>
+      <span className="h-2 w-2 rounded-full bg-current opacity-70" aria-hidden="true" />
+      Refresh: {label}
+      {lastUpdated ? (
+        <span className="text-[11px] font-normal opacity-70">
+          {lastUpdated.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function parseNumber(value: any): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.-]+/g, "");
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function formatPrimitiveValue(fieldName: string, value: any): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+
+  const normalized = normalizeFieldKey(fieldName);
+
+  if (typeof value === "number") {
+    if (/commitment|capital|nav|distribution|gain|loss|cost|value|amount/.test(normalized)) {
+      return formatCurrencyUSD(value);
+    }
+    if (/percent|irr/.test(normalized)) {
+      return formatPercent(value, 2);
+    }
+    if (/moic|multiple/.test(normalized)) {
+      return `${formatNumber(value, 2)}x`;
+    }
+    return formatNumber(value, 2);
+  }
+
+  if (typeof value === "string") {
+    const parsedDate = new Date(value);
+    if (!Number.isNaN(parsedDate.getTime()) && /date|period|as of|paid/.test(normalized)) {
+      return formatDate(parsedDate.toISOString());
+    }
+    if (/commitment|capital|nav|distribution|gain|loss|cost|value|amount/.test(normalized)) {
+      const parsed = parseNumber(value);
+      if (parsed !== null) {
+        return formatCurrencyUSD(parsed);
+      }
+    }
+    if (/percent|irr/.test(normalized)) {
+      const parsed = parseNumber(value);
+      if (parsed !== null) {
+        return formatPercent(parsed, 2);
+      }
+    }
+    if (/moic|multiple/.test(normalized)) {
+      const parsed = parseNumber(value);
+      if (parsed !== null) {
+        return `${formatNumber(parsed, 2)}x`;
+      }
+    }
+    return value || "—";
+  }
+
+  return String(value);
+}
+
+function isLinkedValues(value: any): value is LinkedValue[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => item && typeof item === "object" && "displayName" in item)
+  );
+}
+
+function isAttachmentValues(value: any): value is AttachmentValue[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => item && typeof item === "object" && typeof item.url === "string")
+  );
+}
+
+export default function InvestmentSummaryPage() {
+  const { data, status, error, initialized, lastUpdated } = usePolling<SummaryResponse>(
+    "/api/lp/summary"
+  );
+
+  const fieldOrder = data?.fieldOrder ?? [];
+  const records = data?.records ?? [];
+
+  const handleExport = useCallback(() => {
+    if (!data || !data.records.length || !data.fieldOrder.length) return;
+    const blob = toCsv(data);
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `jbv-investment-summary-${new Date().toISOString().slice(0, 10)}.csv`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  }, [data]);
+
+  const hasData = fieldOrder.length > 0 && records.length > 0;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900">Investment Summary</h2>
+          <p className="text-sm text-slate-500">
+            Transactional-level insights and current metrics pulled directly from Airtable.
+          </p>
+        </div>
+        {buildStatusBadge(status, lastUpdated)}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <button
+          type="button"
+          onClick={handleExport}
+          className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:cursor-not-allowed disabled:bg-blue-200"
+          disabled={!hasData}
+        >
+          Export CSV
+        </button>
+      </div>
+
+      {status === "error" && error ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+          We were unable to refresh your investment summary. Please retry in a moment.
+        </div>
+      ) : null}
+
+      {!initialized ? (
+        <div className="h-64 animate-pulse rounded-2xl bg-gradient-to-br from-slate-200/80 to-slate-100" />
+      ) : records.length === 0 && status !== "error" ? (
+        <div className="rounded-2xl border border-dashed border-slate-200 p-10 text-center text-sm text-slate-500">
+          No data available for your investments. If this seems incorrect, please contact support.
+        </div>
+      ) : hasData ? (
+        <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+          <div className="max-h-[70vh] overflow-auto">
+            <table className="min-w-full text-sm">
+              <thead className="sticky top-0 z-10 bg-slate-100/90 backdrop-blur">
+                <tr>
+                  {fieldOrder.map((field) => (
+                    <th
+                      key={field}
+                      scope="col"
+                      className="whitespace-nowrap px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-600"
+                    >
+                      {field}
+                    </th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {records.map((record) => (
+                  <tr key={record.id} className="odd:bg-white even:bg-slate-50/70">
+                    {fieldOrder.map((field) => {
+                      const value = Object.prototype.hasOwnProperty.call(record.fields, field)
+                        ? record.fields[field]
+                        : undefined;
+                      if (isLinkedValues(value)) {
+                        return (
+                          <td key={field} className="min-w-[12rem] px-4 py-3 align-top text-sm text-slate-700">
+                            <div className="flex flex-wrap gap-2">
+                              {value.map((item) => (
+                                <span
+                                  key={`${record.id}-${field}-${item.id || item.displayName}`}
+                                  className="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600"
+                                >
+                                  {item.displayName || item.id}
+                                </span>
+                              ))}
+                            </div>
+                          </td>
+                        );
+                      }
+                      if (isAttachmentValues(value)) {
+                        return (
+                          <td key={field} className="min-w-[14rem] px-4 py-3 align-top text-sm text-slate-700">
+                            <div className="flex flex-wrap gap-2">
+                              {value.map((attachment, index) => {
+                                const downloadUrl = `/api/lp/documents/download?recordId=${encodeURIComponent(
+                                  record.id
+                                )}&field=${encodeURIComponent(field)}&index=${index}`;
+                                const label = attachment.name || attachment.filename || `File ${index + 1}`;
+                                return (
+                                  <a
+                                    key={`${record.id}-${field}-attachment-${index}`}
+                                    href={downloadUrl}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                    className="inline-flex items-center rounded-md border border-blue-200 bg-white px-3 py-1 text-xs font-medium text-blue-700 transition hover:border-blue-400 hover:bg-blue-50"
+                                  >
+                                    {label}
+                                  </a>
+                                );
+                              })}
+                            </div>
+                          </td>
+                        );
+                      }
+                      if (Array.isArray(value)) {
+                        const parts = value
+                          .map((item) => formatPrimitiveValue(field, item))
+                          .filter((item) => item && item !== "—");
+                        const listDisplay = parts.length ? parts.join(", ") : "—";
+                        return (
+                          <td key={field} className="min-w-[10rem] px-4 py-3 align-top text-sm text-slate-700">
+                            {listDisplay}
+                          </td>
+                        );
+                      }
+                      const display = formatPrimitiveValue(field, value);
+                      return (
+                        <td key={field} className="min-w-[10rem] px-4 py-3 align-top text-sm text-slate-700">
+                          {display}
+                        </td>
+                      );
+                    })}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/lib/csv.ts
+++ b/apps/web/lib/csv.ts
@@ -1,0 +1,147 @@
+import { normalizeFieldKey } from "@/lib/airtable-shared";
+import { formatCurrencyUSD, formatDate, formatNumber, formatPercent } from "@/lib/format";
+
+type SummaryRecord = {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime: string | null;
+};
+
+type SummaryResponse = {
+  fieldOrder: string[];
+  records: SummaryRecord[];
+};
+
+type LinkedValue = { id: string; displayName?: string };
+
+type AttachmentValue = { url?: string; name?: string; filename?: string };
+
+function parseNumber(value: any): number | null {
+  if (value === null || value === undefined) return null;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.-]+/g, "");
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function isLinkedArray(value: any): value is LinkedValue[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => item && typeof item === "object" && "displayName" in item)
+  );
+}
+
+function isAttachmentArray(value: any): value is AttachmentValue[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((item) => item && typeof item === "object" && "url" in item)
+  );
+}
+
+function formatPrimitiveValue(fieldName: string, value: any): string {
+  if (value === null || value === undefined) return "";
+  if (typeof value === "boolean") return value ? "Yes" : "No";
+
+  const normalized = normalizeFieldKey(fieldName);
+
+  if (typeof value === "number") {
+    if (/commitment|capital|nav|distribution|gain|loss|cost|value|amount/.test(normalized)) {
+      return formatCurrencyUSD(value);
+    }
+    if (/percent|irr/.test(normalized)) {
+      return formatPercent(value, 2);
+    }
+    if (/moic|multiple/.test(normalized)) {
+      return `${formatNumber(value, 2)}x`;
+    }
+    return formatNumber(value, 2);
+  }
+
+  if (typeof value === "string") {
+    const parsedDate = new Date(value);
+    if (!Number.isNaN(parsedDate.getTime()) && /date|period|as of|paid/.test(normalized)) {
+      return formatDate(parsedDate.toISOString());
+    }
+    if (/commitment|capital|nav|distribution|gain|loss|cost|value|amount/.test(normalized)) {
+      const parsed = parseNumber(value);
+      if (parsed !== null) {
+        return formatCurrencyUSD(parsed);
+      }
+    }
+    if (/percent|irr/.test(normalized)) {
+      const parsed = parseNumber(value);
+      if (parsed !== null) {
+        return formatPercent(parsed, 2);
+      }
+    }
+    if (/moic|multiple/.test(normalized)) {
+      const parsed = parseNumber(value);
+      if (parsed !== null) {
+        return `${formatNumber(parsed, 2)}x`;
+      }
+    }
+    return value;
+  }
+
+  return String(value);
+}
+
+function formatCellValue(fieldName: string, value: any): string {
+  if (value === null || value === undefined) return "";
+  if (isLinkedArray(value)) {
+    return value.map((item) => item.displayName || "").filter(Boolean).join("; ");
+  }
+  if (isAttachmentArray(value)) {
+    return value
+      .map((item) => item.name || item.filename || item.url || "")
+      .filter(Boolean)
+      .join("; ");
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => formatPrimitiveValue(fieldName, item))
+      .filter((item) => item && item !== "—")
+      .join("; ");
+  }
+  return formatPrimitiveValue(fieldName, value);
+}
+
+function escapeCsvValue(value: string): string {
+  if (value === "") return "";
+  let escaped = value;
+  if (escaped.includes("\"")) {
+    escaped = escaped.replace(/"/g, '""');
+  }
+  if (/[",\n]/.test(escaped)) {
+    return `"${escaped}"`;
+  }
+  return escaped;
+}
+
+export function toCsv(data: SummaryResponse): Blob {
+  const { fieldOrder, records } = data;
+  const lines: string[] = [];
+  lines.push(fieldOrder.map((field) => escapeCsvValue(field)).join(","));
+
+  for (const record of records) {
+    const row = fieldOrder.map((field) => {
+      const value = Object.prototype.hasOwnProperty.call(record.fields, field)
+        ? record.fields[field]
+        : undefined;
+      const formatted = formatCellValue(field, value);
+      return escapeCsvValue(formatted);
+    });
+    lines.push(row.join(","));
+  }
+
+  const csvContent = lines.join("\r\n");
+  return new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+}
+
+export type { SummaryRecord, SummaryResponse };


### PR DESCRIPTION
## Summary
- add an LP summary API that expands linked investments, enforces visibility, and returns a curated field order
- add the Investment Summary LP tab with a polling table view, attachment links, and CSV export
- add a shared CSV utility for formatting summary data for download

## Testing
- npm run lint --prefix apps/web

------
https://chatgpt.com/codex/tasks/task_b_68cb2d9167a48320a0deddf7d4767b03