### PR TITLE
Add LP investment summary tab with CSV export

### DIFF
--- a/apps/web/app/api/lp/summary/route.ts
+++ b/apps/web/app/api/lp/summary/route.ts
@@ -1,0 +1,157 @@
+import { getSession } from "@/lib/auth";
+import { type Role } from "@/lib/auth-helpers";
+import { applyVisibility, expandLinked, findContactsByEmail, getInvestmentsForContactIds } from "@/lib/lp-server";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const VIEW_ID = process.env.AIRTABLE_VIEW_ID;
+
+const LINKED_FIELD_NAMES = new Set(["Partner", "Fund", "Target Securities", "Primary Contact", "PRIMARY CONTACT"]);
+
+const CURATED_FIELDS = [
+  "Partner Investment",
+  "Partner",
+  "Fund",
+  "Status",
+  "Commitment",
+  "Contributed / Total LP Commitment",
+  "Current NAV",
+  "Total NAV",
+  "Distributions",
+  "Gain / Loss",
+  "Net MOIC",
+  "FMV / Share",
+  "Cost / Share",
+  "Paid Dates",
+  "Period Ending",
+  "Vintage",
+  "Investment Year (K-1 Formula)",
+  "Target Securities",
+  "Subscription Doc",
+  "Latest PCAP File",
+  "PCAP Distribution Report",
+  "Calculation",
+  "Status (I)",
+  "SubDoc Name",
+  "PRIMARY CONTACT",
+  "Primary Contact",
+];
+
+type SummaryRecord = {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime: string | null;
+};
+
+type SummaryResponse = {
+  fieldOrder: string[];
+  records: SummaryRecord[];
+};
+
+function sanitizeFields(fields: Record<string, any>) {
+  const sanitized: Record<string, any> = {};
+  for (const [key, value] of Object.entries(fields)) {
+    if (LINKED_FIELD_NAMES.has(key) && Array.isArray(value)) {
+      sanitized[key] = value
+        .filter((entry) => entry !== null && entry !== undefined)
+        .map((entry) => {
+          if (entry && typeof entry === "object") {
+            const idValue = entry.id ?? entry.recordId ?? entry.displayName;
+            const id = idValue != null ? String(idValue) : "";
+            const displayNameValue =
+              entry.displayName ?? entry.name ?? entry.fields?.Name ?? entry.fields?.["Full Name"];
+            const displayName = displayNameValue != null ? String(displayNameValue) : id;
+            return { id, displayName };
+          }
+          const asString = String(entry);
+          return { id: asString, displayName: asString };
+        });
+      continue;
+    }
+    sanitized[key] = value;
+  }
+  return sanitized;
+}
+
+function buildFieldOrder(records: SummaryRecord[]) {
+  const encountered: string[] = [];
+  const seen = new Set<string>();
+  records.forEach((record) => {
+    const fields = record.fields || {};
+    Object.keys(fields).forEach((key) => {
+      if (!seen.has(key)) {
+        seen.add(key);
+        encountered.push(key);
+      }
+    });
+  });
+
+  if (!encountered.length) return [];
+
+  const curated: string[] = [];
+  const curatedSet = new Set<string>();
+  for (const field of CURATED_FIELDS) {
+    if (seen.has(field) && !curatedSet.has(field)) {
+      curated.push(field);
+      curatedSet.add(field);
+    }
+  }
+
+  const additional = encountered.filter((field) => !curatedSet.has(field));
+  additional.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: "base" }));
+
+  return [...curated, ...additional];
+}
+
+export async function GET() {
+  try {
+    const session = await getSession();
+    const user = session?.user;
+    const email = user?.email;
+    if (!session || !user || !email) {
+      return Response.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const role = (user.role as Role | undefined) ?? "lp";
+    const contacts = await findContactsByEmail(email);
+    const contactIds = contacts.map((contact) => contact.id);
+
+    if (!contactIds.length) {
+      const payload: SummaryResponse = { fieldOrder: [], records: [] };
+      return Response.json(payload);
+    }
+
+    const investments = await getInvestmentsForContactIds(contactIds, VIEW_ID);
+    if (!investments.length) {
+      const payload: SummaryResponse = { fieldOrder: [], records: [] };
+      return Response.json(payload);
+    }
+
+    const expanded = await Promise.all(investments.map((record) => expandLinked(record)));
+    const visible = await Promise.all(
+      expanded.map(async (record) => {
+        const allowed = await applyVisibility(record.fields, role);
+        const sanitized = sanitizeFields(allowed);
+        return {
+          id: record.id,
+          fields: sanitized,
+          _updatedTime: record._updatedTime ?? null,
+        } as SummaryRecord;
+      })
+    );
+
+    const filtered = visible.filter((record) => Object.keys(record.fields).length > 0);
+    if (!filtered.length) {
+      const payload: SummaryResponse = { fieldOrder: [], records: [] };
+      return Response.json(payload);
+    }
+
+    const fieldOrder = buildFieldOrder(filtered);
+    const payload: SummaryResponse = { fieldOrder, records: filtered };
+    return Response.json(payload);
+  } catch (error: any) {
+    console.error("[lp-summary] Failed to load LP summary", error);
+    return Response.json({ error: error?.message || "Failed to load summary" }, { status: 500 });
+  }
+}

--- a/apps/web/app/lp/layout.tsx
+++ b/apps/web/app/lp/layout.tsx
@@ -9,6 +9,7 @@ const NAV_ITEMS = [
   { href: "/lp/investments", label: "Investments" },
   { href: "/lp/docs", label: "Documents" },
   { href: "/lp/help", label: "Help" },
+  { href: "/lp/summary", label: "Investment Summary" },
 ];
 
 type Profile = {

--- a/apps/web/app/lp/summary/page.tsx
+++ b/apps/web/app/lp/summary/page.tsx
@@ -1,0 +1,313 @@
+"use client";
+
+import { useMemo } from "react";
+
+import { normalizeFieldKey } from "@/lib/airtable-shared";
+import { toCsv } from "@/lib/csv";
+import { formatCurrencyUSD, formatDate, formatNumber, formatPercent } from "@/lib/format";
+import { usePolling, type RefreshStatus } from "@/hooks/usePolling";
+
+type SummaryRecord = {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime: string | null;
+};
+
+type SummaryResponse = {
+  fieldOrder: string[];
+  records: SummaryRecord[];
+};
+
+function buildStatusBadge(status: RefreshStatus, lastUpdated: Date | null) {
+  const label = status === "refreshing" ? "Refreshing" : status === "error" ? "Error" : "Idle";
+  const tone =
+    status === "refreshing"
+      ? "bg-blue-50 text-blue-600"
+      : status === "error"
+      ? "bg-red-50 text-red-600"
+      : "bg-emerald-50 text-emerald-600";
+
+  return (
+    <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold ${tone}`}>
+      <span className="h-2 w-2 rounded-full bg-current opacity-70" aria-hidden="true" />
+      Refresh: {label}
+      {lastUpdated ? (
+        <span className="text-[11px] font-normal opacity-70">
+          {lastUpdated.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+        </span>
+      ) : null}
+    </span>
+  );
+}
+
+function parseNumberValue(value: any): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.-]+/g, "");
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function isCurrencyField(normalized: string) {
+  return /commitment|capital|nav|distribution|gain|loss|cost|contributed|value|amount|fmv|paid/.test(normalized);
+}
+
+function isPercentField(normalized: string) {
+  return /percent|irr|yield|rate/.test(normalized);
+}
+
+function isMoicField(normalized: string) {
+  return /moic|multiple/.test(normalized);
+}
+
+function isDateField(normalized: string) {
+  return /date|period|as of|paid/.test(normalized);
+}
+
+function formatPrimitiveValue(field: string, value: number | string) {
+  const normalized = normalizeFieldKey(field);
+  if (typeof value === "number") {
+    if (isCurrencyField(normalized)) {
+      return formatCurrencyUSD(value);
+    }
+    if (isPercentField(normalized)) {
+      return formatPercent(value);
+    }
+    if (isMoicField(normalized)) {
+      return `${formatNumber(value, 2)}x`;
+    }
+    return formatNumber(value, 2);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return "—";
+
+  if (isDateField(normalized)) {
+    const formatted = formatDate(value);
+    if (formatted !== "—") return formatted;
+  }
+
+  const parsed = parseNumberValue(value);
+  if (parsed !== null) {
+    if (isCurrencyField(normalized)) {
+      return formatCurrencyUSD(parsed);
+    }
+    if (isPercentField(normalized)) {
+      return formatPercent(parsed);
+    }
+    if (isMoicField(normalized)) {
+      return `${formatNumber(parsed, 2)}x`;
+    }
+  }
+
+  if (isPercentField(normalized) && /%$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (isMoicField(normalized) && /x$/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return trimmed;
+}
+
+function renderAttachmentLinks(recordId: string, field: string, attachments: any[]) {
+  const hasLinks = attachments.some((item) => item && typeof item === "object" && typeof item.url === "string");
+  if (!hasLinks) {
+    return <span className="text-slate-500">—</span>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-2">
+      {attachments.map((attachment, index) => {
+        if (!attachment || typeof attachment !== "object" || typeof attachment.url !== "string") {
+          return null;
+        }
+        const downloadUrl = `/api/lp/documents/download?recordId=${encodeURIComponent(
+          recordId
+        )}&field=${encodeURIComponent(field)}&index=${index}`;
+        const label = attachment.name || attachment.filename || attachment.title || `Document ${index + 1}`;
+        return (
+          <a
+            key={`${recordId}-${field}-${index}`}
+            href={downloadUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center rounded-full border border-blue-200 px-3 py-1 text-xs font-semibold text-blue-600 transition hover:border-blue-400 hover:bg-blue-50"
+          >
+            {label}
+          </a>
+        );
+      })}
+    </div>
+  );
+}
+
+function renderFieldValue(recordId: string, field: string, value: any) {
+  if (value === null || value === undefined || value === "") {
+    return <span className="text-slate-400">—</span>;
+  }
+
+  if (Array.isArray(value)) {
+    if (!value.length) return <span className="text-slate-400">—</span>;
+    const linked = value.filter((entry) => entry && typeof entry === "object" && "displayName" in entry);
+    if (linked.length) {
+      return (
+        <div className="flex flex-wrap gap-2">
+          {linked.map((entry: any, index: number) => {
+            const key = entry.id || entry.displayName || entry.name || index;
+            const label = entry.displayName || entry.name || entry.id || "—";
+            return (
+              <span
+                key={key}
+                className="inline-flex items-center rounded-full bg-slate-100 px-2 py-0.5 text-xs text-slate-600"
+              >
+                {label}
+              </span>
+            );
+          })}
+        </div>
+      );
+    }
+
+    const attachments = value.filter((entry) => entry && typeof entry === "object" && typeof entry.url === "string");
+    if (attachments.length) {
+      return renderAttachmentLinks(recordId, field, attachments);
+    }
+
+    const parts = value
+      .map((entry) => (entry !== null && entry !== undefined ? String(entry) : ""))
+      .filter(Boolean);
+    if (!parts.length) {
+      return <span className="text-slate-400">—</span>;
+    }
+    return <span>{parts.join(", ")}</span>;
+  }
+
+  if (typeof value === "boolean") {
+    return <span>{value ? "Yes" : "No"}</span>;
+  }
+
+  if (typeof value === "number" || typeof value === "string") {
+    const formatted = formatPrimitiveValue(field, value as any);
+    return <span>{formatted || "—"}</span>;
+  }
+
+  if (value && typeof value === "object" && typeof (value as any).url === "string") {
+    return renderAttachmentLinks(recordId, field, [value]);
+  }
+
+  if (value && typeof value === "object") {
+    try {
+      return <span>{JSON.stringify(value)}</span>;
+    } catch {
+      return <span>{String(value)}</span>;
+    }
+  }
+
+  return <span>{String(value)}</span>;
+}
+
+export default function InvestmentSummaryPage() {
+  const { data, status, error, initialized, lastUpdated } = usePolling<SummaryResponse>("/api/lp/summary");
+
+  const fieldOrder = useMemo(() => data?.fieldOrder ?? [], [data?.fieldOrder]);
+  const records = useMemo(() => data?.records ?? [], [data?.records]);
+
+  const handleExport = () => {
+    if (!data || !data.records.length) {
+      return;
+    }
+    const blob = toCsv({ fieldOrder: data.fieldOrder, records: data.records });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `jbv-investment-summary-${new Date().toISOString().slice(0, 10)}.csv`;
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
+  };
+
+  const showEmptyState = initialized && status !== "error" && (!records.length || !fieldOrder.length);
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-900">Investment Summary</h2>
+          <p className="text-sm text-slate-500">
+            Consolidated view of your commitments, valuations, and partner updates from Airtable.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          {buildStatusBadge(status, lastUpdated)}
+          <button
+            type="button"
+            onClick={handleExport}
+            className="inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:cursor-not-allowed disabled:bg-slate-300"
+            disabled={!records.length || !fieldOrder.length}
+          >
+            Export CSV
+          </button>
+        </div>
+      </div>
+
+      {status === "error" && error ? (
+        <div className="rounded-2xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-600">
+          We were unable to refresh your investment summary. Please try again shortly.
+        </div>
+      ) : null}
+
+      {!initialized ? (
+        <div className="h-64 animate-pulse rounded-2xl bg-gradient-to-br from-slate-200/80 to-slate-100" />
+      ) : showEmptyState ? (
+        <div className="rounded-2xl border border-dashed border-slate-200 p-10 text-center text-sm text-slate-500">
+          No data available for your investments. If this seems incorrect, please contact support.
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-2xl bg-white shadow-sm ring-1 ring-slate-200">
+          <table className="min-w-full divide-y divide-slate-200 text-sm">
+            <thead className="bg-slate-100/80">
+              <tr>
+                {fieldOrder.map((field) => (
+                  <th
+                    key={field}
+                    scope="col"
+                    className="whitespace-nowrap px-4 py-3 text-left text-xs font-semibold uppercase tracking-wide text-slate-600"
+                  >
+                    {field}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-slate-100">
+              {records.map((record) => (
+                <tr
+                  key={record.id}
+                  className="odd:bg-white even:bg-slate-50/60 hover:bg-blue-50/40"
+                >
+                  {fieldOrder.map((field) => {
+                    const value = Object.prototype.hasOwnProperty.call(record.fields, field)
+                      ? record.fields[field]
+                      : undefined;
+                    return (
+                      <td key={field} className="whitespace-nowrap px-4 py-2 align-top text-slate-700">
+                        {renderFieldValue(record.id, field, value)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/lib/csv.ts
+++ b/apps/web/lib/csv.ts
@@ -1,0 +1,189 @@
+"use client";
+
+import { normalizeFieldKey } from "@/lib/airtable-shared";
+import { formatCurrencyUSD, formatDate, formatNumber, formatPercent } from "@/lib/format";
+
+type CsvRecord = {
+  id: string;
+  fields: Record<string, any>;
+  _updatedTime?: string | null;
+};
+
+type CsvInput = {
+  fieldOrder: string[];
+  records: CsvRecord[];
+};
+
+function parseNumberValue(value: any): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string") {
+    const cleaned = value.replace(/[^0-9.-]+/g, "");
+    if (!cleaned) return null;
+    const parsed = Number(cleaned);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function isCurrencyField(normalized: string) {
+  return /commitment|capital|nav|distribution|gain|loss|cost|contributed|value|amount|fmv|paid/.test(normalized);
+}
+
+function isPercentField(normalized: string) {
+  return /percent|irr|yield|rate/.test(normalized);
+}
+
+function isMoicField(normalized: string) {
+  return /moic|multiple/.test(normalized);
+}
+
+function isDateField(normalized: string) {
+  return /date|period|as of|paid/.test(normalized);
+}
+
+function escapeCsvValue(value: string) {
+  if (value.includes("\"")) {
+    value = value.replace(/"/g, '""');
+  }
+  if (/[",\n\r]/.test(value)) {
+    return `"${value}"`;
+  }
+  return value;
+}
+
+function isLinkedArray(value: any[]): boolean {
+  return value.some((entry) => entry && typeof entry === "object" && "displayName" in entry);
+}
+
+function isAttachmentEntry(entry: any): boolean {
+  return entry && typeof entry === "object" && typeof entry.url === "string";
+}
+
+function formatAttachmentValue(recordId: string, field: string, attachments: any[]): string {
+  const parts = attachments
+    .map((entry, index) => {
+      if (!isAttachmentEntry(entry)) return null;
+      const downloadUrl = `/api/lp/documents/download?recordId=${encodeURIComponent(
+        recordId
+      )}&field=${encodeURIComponent(field)}&index=${index}`;
+      const label = entry.name || entry.filename || entry.title;
+      return label ? `${label} (${downloadUrl})` : downloadUrl;
+    })
+    .filter((value): value is string => Boolean(value));
+  return parts.join("; ");
+}
+
+function formatPrimitiveValue(field: string, value: number | string): string {
+  const normalized = normalizeFieldKey(field);
+  if (typeof value === "number") {
+    if (isCurrencyField(normalized)) {
+      return formatCurrencyUSD(value);
+    }
+    if (isPercentField(normalized)) {
+      return formatPercent(value);
+    }
+    if (isMoicField(normalized)) {
+      return `${formatNumber(value, 2)}x`;
+    }
+    return formatNumber(value, 2);
+  }
+
+  const trimmed = value.trim();
+  if (!trimmed) return "";
+
+  if (isDateField(normalized)) {
+    const formatted = formatDate(value);
+    if (formatted !== "—") return formatted;
+  }
+
+  const parsed = parseNumberValue(value);
+  if (parsed !== null) {
+    if (isCurrencyField(normalized)) {
+      return formatCurrencyUSD(parsed);
+    }
+    if (isPercentField(normalized)) {
+      return formatPercent(parsed);
+    }
+    if (isMoicField(normalized)) {
+      return `${formatNumber(parsed, 2)}x`;
+    }
+  }
+
+  if (isPercentField(normalized) && /%$/.test(trimmed)) {
+    return trimmed;
+  }
+
+  if (isMoicField(normalized) && /x$/i.test(trimmed)) {
+    return trimmed;
+  }
+
+  return trimmed;
+}
+
+function formatValueForCsv(field: string, value: any, recordId: string): string {
+  if (value === null || value === undefined) return "";
+
+  if (Array.isArray(value)) {
+    if (!value.length) return "";
+    if (isLinkedArray(value)) {
+      return value
+        .map((entry) => {
+          if (entry && typeof entry === "object") {
+            const name = entry.displayName ?? entry.name ?? entry.id;
+            return name != null ? String(name) : "";
+          }
+          return entry != null ? String(entry) : "";
+        })
+        .filter(Boolean)
+        .join("; ");
+    }
+    if (value.some((entry) => isAttachmentEntry(entry))) {
+      return formatAttachmentValue(recordId, field, value);
+    }
+    return value
+      .map((entry) => (entry != null ? String(entry) : ""))
+      .filter(Boolean)
+      .join("; ");
+  }
+
+  if (typeof value === "boolean") {
+    return value ? "Yes" : "No";
+  }
+
+  if (typeof value === "number" || typeof value === "string") {
+    return formatPrimitiveValue(field, value as any);
+  }
+
+  if (value && typeof value === "object") {
+    if (isAttachmentEntry(value)) {
+      return formatAttachmentValue(recordId, field, [value]);
+    }
+    try {
+      return JSON.stringify(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  return String(value);
+}
+
+export function toCsv({ fieldOrder, records }: CsvInput): Blob {
+  const rows: string[][] = [];
+  rows.push(fieldOrder.slice());
+
+  records.forEach((record) => {
+    const row = fieldOrder.map((field) => {
+      const value = Object.prototype.hasOwnProperty.call(record.fields, field)
+        ? record.fields[field]
+        : undefined;
+      return formatValueForCsv(field, value, record.id);
+    });
+    rows.push(row);
+  });
+
+  const csvContent = rows.map((row) => row.map((cell) => escapeCsvValue(cell ?? "")).join(",")).join("\r\n");
+  return new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+}


### PR DESCRIPTION
## Summary
- add an LP summary API that expands linked records, enforces visibility, and returns a curated field order
- implement the LP Investment Summary page with polling, striped table rendering, and attachment handling
- add a CSV export helper and surface the new summary tab in the LP navigation

## Testing
- npm run lint --prefix apps/web

------
https://chatgpt.com/codex/tasks/task_b_68cb2d9167a48320a0deddf7d4767b03