### PR TITLE
Add privacy and terms governance across portal

### DIFF
--- a/apps/web/app/auth/signin/page.tsx
+++ b/apps/web/app/auth/signin/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { FormEvent, Suspense, useMemo, useState } from "react";
 import { signIn } from "next-auth/react";
 import { useSearchParams } from "next/navigation";
@@ -112,6 +113,18 @@ function SignInForm() {
               {errorMessage || queryError}
             </div>
           )}
+
+          <p className="text-xs text-slate-500">
+            By logging in, you acknowledge that you have read and agree to the {" "}
+            <Link className="font-semibold text-blue-600 hover:underline" href="/terms-of-use">
+              Terms of Use
+            </Link>{" "}
+            and that you have reviewed the {" "}
+            <Link className="font-semibold text-blue-600 hover:underline" href="/privacy-policy">
+              Privacy Policy
+            </Link>
+            .
+          </p>
 
           <p className="text-xs text-slate-500">
             Need assistance? Contact your JBV relationship manager or email

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,6 @@
 import "@/styles/globals.css";
 import React from "react";
+import { SiteFooter } from "@/components/site-footer";
 
 export const metadata = {
   title: "JBV Investment Platform",
@@ -9,7 +10,12 @@ export const metadata = {
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body className="bg-white text-slate-900">{children}</body>
+      <body className="bg-white text-slate-900">
+        <div className="flex min-h-screen flex-col">
+          <div className="flex-1">{children}</div>
+          <SiteFooter />
+        </div>
+      </body>
     </html>
   );
 }

--- a/apps/web/app/lp/help/page.tsx
+++ b/apps/web/app/lp/help/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 export default function HelpPage() {
   return (
     <div className="space-y-4">
@@ -15,6 +17,24 @@ export default function HelpPage() {
           <li>Dashboard data refreshes automatically every 15 seconds and when you return to the window.</li>
           <li>Export holdings to CSV directly from the Investments tab for offline analysis.</li>
           <li>Documents are grouped by investment, and new files appear instantly when uploaded to Airtable.</li>
+        </ul>
+      </div>
+      <div className="space-y-3 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
+        <h3 className="text-lg font-semibold text-slate-900">Compliance &amp; Legal References</h3>
+        <p className="text-sm text-slate-600">
+          Review the governing policies for the Portal at any time via the resources below.
+        </p>
+        <ul className="space-y-2 text-sm text-slate-600">
+          <li>
+            <Link className="font-semibold text-blue-600 hover:underline" href="/privacy-policy">
+              Privacy Policy of the JBV Investment Capital Limited Partner Portal
+            </Link>
+          </li>
+          <li>
+            <Link className="font-semibold text-blue-600 hover:underline" href="/terms-of-use">
+              Terms of Use of the JBV Investment Capital Limited Partner Portal
+            </Link>
+          </li>
         </ul>
       </div>
     </div>

--- a/apps/web/app/lp/layout.tsx
+++ b/apps/web/app/lp/layout.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { FormEvent, useEffect, useMemo, useState, type ReactNode } from "react";
 
 const NAV_ITEMS = [
   { href: "/lp", label: "Overview" },
@@ -11,6 +11,8 @@ const NAV_ITEMS = [
   { href: "/lp/help", label: "Help" },
   { href: "/lp/summary", label: "Investment Summary" },
 ];
+
+const POLICY_STORAGE_KEY = "jbv-portal-policy-ack-20250917";
 
 type Profile = {
   name: string;
@@ -22,6 +24,13 @@ export default function LPLayout({ children }: { children: ReactNode }) {
   const [profile, setProfile] = useState<Profile | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(false);
+  const [policyAcknowledged, setPolicyAcknowledged] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const stored = window.localStorage.getItem(POLICY_STORAGE_KEY);
+    setPolicyAcknowledged(stored === "true");
+  }, []);
 
   useEffect(() => {
     let isMounted = true;
@@ -81,55 +90,148 @@ export default function LPLayout({ children }: { children: ReactNode }) {
     return { label: "Connecting…", tone: "text-slate-500", dot: "bg-slate-300" };
   }, [profile, error]);
 
+  const handlePolicyAcknowledgement = () => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(POLICY_STORAGE_KEY, "true");
+    }
+    setPolicyAcknowledged(true);
+  };
+
+  const isPolicyGateActive = policyAcknowledged === false;
+
   return (
-    <div className="min-h-screen bg-slate-50">
-      <header className="border-b border-slate-200 bg-white">
-        <div className="mx-auto max-w-7xl px-6 py-8">
-          <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
-            <div className="space-y-2">
-              <p className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">JBV Investment Platform</p>
-              <h1 className="text-3xl font-semibold text-slate-900">Limited Partner Experience</h1>
-              <p className="text-sm text-slate-500">
-                Insights, performance, and documents tailored to your investments.
-              </p>
+    <>
+      <div aria-hidden={isPolicyGateActive} className="min-h-screen bg-slate-50">
+        <header className="border-b border-slate-200 bg-white">
+          <div className="mx-auto max-w-7xl px-6 py-8">
+            <div className="flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
+              <div className="space-y-2">
+                <p className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">JBV Investment Platform</p>
+                <h1 className="text-3xl font-semibold text-slate-900">Limited Partner Experience</h1>
+                <p className="text-sm text-slate-500">
+                  Insights, performance, and documents tailored to your investments.
+                </p>
+              </div>
+              <div className="flex items-center gap-3 rounded-full border border-slate-200 bg-white px-4 py-2 shadow-sm">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-sm font-semibold text-white">
+                  {initials}
+                </div>
+                <div className="flex flex-col">
+                  <span className="text-sm font-semibold text-slate-900">
+                    {profile?.name || (loading ? "Loading investor" : "Investor")}
+                  </span>
+                  <span className="text-xs text-slate-500">{profile?.email || (error ? "Unavailable" : "")}</span>
+                </div>
+                <div className={`flex items-center gap-2 text-xs font-medium ${status.tone}`}>
+                  <span className={`h-2 w-2 rounded-full ${status.dot}`} aria-hidden="true" />
+                  {status.label}
+                </div>
+              </div>
             </div>
-            <div className="flex items-center gap-3 rounded-full border border-slate-200 bg-white px-4 py-2 shadow-sm">
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 text-sm font-semibold text-white">
-                {initials}
-              </div>
-              <div className="flex flex-col">
-                <span className="text-sm font-semibold text-slate-900">
-                  {profile?.name || (loading ? "Loading investor" : "Investor")}
-                </span>
-                <span className="text-xs text-slate-500">{profile?.email || (error ? "Unavailable" : "")}</span>
-              </div>
-              <div className={`flex items-center gap-2 text-xs font-medium ${status.tone}`}>
-                <span className={`h-2 w-2 rounded-full ${status.dot}`} aria-hidden="true" />
-                {status.label}
-              </div>
-            </div>
+            <nav className="mt-6 flex flex-wrap gap-2 text-sm font-medium">
+              {NAV_ITEMS.map((item) => {
+                const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
+                return (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    className={`rounded-full px-4 py-2 transition ${
+                      isActive
+                        ? "bg-blue-600 text-white shadow"
+                        : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
+                    }`}
+                  >
+                    {item.label}
+                  </Link>
+                );
+              })}
+            </nav>
           </div>
-          <nav className="mt-6 flex flex-wrap gap-2 text-sm font-medium">
-            {NAV_ITEMS.map((item) => {
-              const isActive = pathname === item.href || pathname.startsWith(`${item.href}/`);
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={`rounded-full px-4 py-2 transition ${
-                    isActive
-                      ? "bg-blue-600 text-white shadow"
-                      : "text-slate-600 hover:bg-slate-100 hover:text-slate-900"
-                  }`}
-                >
-                  {item.label}
-                </Link>
-              );
-            })}
-          </nav>
+        </header>
+        <main className="mx-auto max-w-7xl px-6 py-10">{children}</main>
+      </div>
+      {isPolicyGateActive ? (
+        <PolicyAcknowledgementOverlay onAccept={handlePolicyAcknowledgement} />
+      ) : null}
+    </>
+  );
+}
+
+function PolicyAcknowledgementOverlay({ onAccept }: { onAccept: () => void }) {
+  const [termsAccepted, setTermsAccepted] = useState(false);
+  const [privacyAcknowledged, setPrivacyAcknowledged] = useState(false);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (termsAccepted && privacyAcknowledged) {
+      onAccept();
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/70 px-4 py-6">
+      <div
+        aria-labelledby="policy-acknowledgement-title"
+        aria-modal="true"
+        role="dialog"
+        className="w-full max-w-lg space-y-6 rounded-2xl bg-white p-8 shadow-xl"
+      >
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">Legal Acknowledgement</p>
+          <h2 className="text-2xl font-semibold text-slate-900" id="policy-acknowledgement-title">
+            Confirm Limited Partner Access
+          </h2>
+          <p className="text-sm text-slate-600">
+            To proceed, please confirm the governing policies for the JBV Investment Capital Limited Partner Portal.
+          </p>
         </div>
-      </header>
-      <main className="mx-auto max-w-7xl px-6 py-10">{children}</main>
+        <form className="space-y-5" onSubmit={handleSubmit}>
+          <div className="space-y-3">
+            <label className="flex items-start gap-3 text-sm text-slate-700">
+              <input
+                checked={termsAccepted}
+                className="mt-1 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                onChange={(event) => setTermsAccepted(event.target.checked)}
+                required
+                type="checkbox"
+              />
+              <span>
+                I have read and agree to the {" "}
+                <Link className="font-semibold text-blue-600 hover:underline" href="/terms-of-use">
+                  Terms of Use
+                </Link>
+                .
+              </span>
+            </label>
+            <label className="flex items-start gap-3 text-sm text-slate-700">
+              <input
+                checked={privacyAcknowledged}
+                className="mt-1 h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500"
+                onChange={(event) => setPrivacyAcknowledged(event.target.checked)}
+                required
+                type="checkbox"
+              />
+              <span>
+                I acknowledge that I have reviewed the {" "}
+                <Link className="font-semibold text-blue-600 hover:underline" href="/privacy-policy">
+                  Privacy Policy
+                </Link>
+                .
+              </span>
+            </label>
+          </div>
+          <button
+            className="w-full rounded-lg bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600 disabled:cursor-not-allowed disabled:bg-blue-300"
+            disabled={!termsAccepted || !privacyAcknowledged}
+            type="submit"
+          >
+            Acknowledge &amp; Continue
+          </button>
+          <p className="text-xs text-slate-500">
+            Portal access remains restricted to authorized Limited Partners and their expressly designated representatives.
+          </p>
+        </form>
+      </div>
     </div>
   );
 }

--- a/apps/web/app/privacy-policy/page.tsx
+++ b/apps/web/app/privacy-policy/page.tsx
@@ -1,0 +1,101 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Privacy Policy | JBV Investment Capital Limited Partner Portal",
+  description:
+    "Privacy Policy governing the collection, processing, and protection of information within the JBV Investment Capital Limited Partner Portal.",
+};
+
+const EFFECTIVE_DATE = "September 17, 2025";
+
+export default function PrivacyPolicyPage() {
+  return (
+    <div className="bg-slate-50">
+      <div className="mx-auto max-w-4xl px-6 py-16">
+        <header className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">Compliance Notice</p>
+          <h1 className="text-3xl font-semibold text-slate-900">Privacy Policy of JBV Investment Capital Limited Partner Portal</h1>
+          <p className="text-sm text-slate-500">Effective Date: {EFFECTIVE_DATE}</p>
+        </header>
+
+        <div className="mt-10 space-y-6 text-sm leading-6 text-slate-700">
+          <p>
+            This Privacy Policy (the “Policy”) is promulgated by JBV Investment Capital, together with its affiliates
+            (collectively, “JBV,” “we,” “our,” or “us”), for the purpose of establishing the principles under which
+            information concerning Limited Partners (“LPs,” “you,” or “your”) is collected, processed, retained, and
+            disclosed in connection with the use of the JBV Limited Partner Portal (the “Portal”). By accessing the Portal,
+            you acknowledge and consent to the terms of this Policy, as may be amended from time to time.
+          </p>
+          <p>
+            JBV collects information that is necessary or appropriate for the administration of your investment in one or
+            more funds sponsored or advised by JBV. Such information may include personal data, such as name, contact
+            details, government-issued identifiers, and documentation required for anti-money laundering and
+            know-your-customer purposes; financial and transactional data, including capital commitments, contributions,
+            distributions, banking details, and tax documents; technical data derived from your use of the Portal, such as
+            login activity, internet protocol addresses, device identifiers, and security logs; and records of
+            communications between you and JBV personnel.
+          </p>
+          <p>
+            The information so collected is processed for purposes including the administration of your investment
+            relationship; compliance with contractual, legal, regulatory, and tax obligations; the authentication and
+            maintenance of secure access to the Portal; the preparation and dissemination of reports, notices, and
+            statements; and the maintenance and improvement of Portal security and functionality.
+          </p>
+          <p>
+            JBV may disclose information to third parties strictly to the extent necessary to facilitate the foregoing
+            purposes. Such parties may include fund administrators, custodians, auditors, technology and cybersecurity
+            service providers, legal and financial advisors, and, where required, governmental and regulatory authorities.
+            JBV does not sell, lease, or otherwise commercially exploit personal data for unrelated purposes.
+          </p>
+          <p>
+            JBV employs commercially reasonable and industry-standard physical, electronic, and administrative safeguards
+            intended to preserve the confidentiality, integrity, and security of information maintained within the Portal.
+            Notwithstanding the adoption of such safeguards, no system of electronic transmission or storage can be
+            guaranteed to be wholly secure, and JBV makes no representation or warranty with respect to the absolute
+            security of information transmitted or stored through the Portal.
+          </p>
+          <p>
+            Information shall be retained only so long as necessary to achieve the purposes set forth herein, including
+            compliance with applicable contractual, regulatory, and record-keeping obligations, following which such
+            information shall be securely deleted or anonymized in accordance with JBV’s internal retention policies.
+          </p>
+          <p>
+            Depending on your jurisdiction, you may have certain rights under applicable data protection laws, including
+            rights of access, rectification, erasure, restriction, and objection. The exercise of such rights may be
+            subject to limitations imposed by legal, regulatory, or contractual requirements. All requests in respect of
+            such rights must be directed in writing to the JBV Compliance Department at the contact details provided below.
+          </p>
+          <p>
+            Because JBV conducts business on a global basis, your information may be transferred across national borders.
+            Where such transfers occur, JBV will implement appropriate safeguards, including contractual undertakings or
+            regulatory authorizations, to ensure adequate protection of your information.
+          </p>
+          <p>
+            JBV reserves the right to amend this Policy at its discretion. Amendments shall become effective upon their
+            posting to the Portal, together with an updated effective date. Your continued use of the Portal following
+            such posting shall constitute your acceptance of the Policy as amended.
+          </p>
+          <p>Questions concerning this Policy should be directed to:</p>
+          <address className="not-italic text-sm text-slate-700">
+            <div>JBV Investment Capital – Compliance Department</div>
+            <div>405 Lexington Avenue, 32nd Floor</div>
+            <div>New York, NY 10174</div>
+            <div>
+              Email: {" "}
+              <a className="font-semibold text-blue-600 hover:underline" href="mailto:compliance@jbvcapital.com">
+                compliance@jbvcapital.com
+              </a>
+            </div>
+          </address>
+          <p className="text-xs text-slate-500">
+            For additional information about your use of the Portal, please review the {" "}
+            <Link className="font-semibold text-blue-600 hover:underline" href="/terms-of-use">
+              Terms of Use
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/terms-of-use/page.tsx
+++ b/apps/web/app/terms-of-use/page.tsx
@@ -1,0 +1,131 @@
+import Link from "next/link";
+
+export const metadata = {
+  title: "Terms of Use | JBV Investment Capital Limited Partner Portal",
+  description:
+    "Terms of Use governing access to and use of the JBV Investment Capital Limited Partner Portal, including the restricted access legal disclaimer.",
+};
+
+const EFFECTIVE_DATE = "September 17, 2025";
+const LAST_UPDATED = "September 17, 2025";
+
+export default function TermsOfUsePage() {
+  return (
+    <div className="bg-slate-50">
+      <div className="mx-auto max-w-4xl px-6 py-16">
+        <header className="space-y-3">
+          <p className="text-xs font-semibold uppercase tracking-[0.35em] text-blue-600">Compliance Notice</p>
+          <h1 className="text-3xl font-semibold text-slate-900">Terms of Use of JBV Investment Capital Limited Partner Portal</h1>
+          <div className="text-sm text-slate-500">
+            <p>Effective Date: {EFFECTIVE_DATE}</p>
+            <p>Last Updated: {LAST_UPDATED}</p>
+          </div>
+        </header>
+
+        <div className="mt-10 space-y-6 text-sm leading-6 text-slate-700">
+          <p>
+            These Terms of Use (the “Terms”) govern the access to and use of the Limited Partner Portal (the “Portal”)
+            maintained by JBV Investment Capital, together with its affiliates (collectively, “JBV,” “we,” “our,” or “us”).
+            By accessing the Portal, each user (“you” or the “User”) acknowledges that he, she, or it has read, understood,
+            and agrees to be bound by these Terms. If you do not agree, you are not authorized to access the Portal.
+          </p>
+          <p>
+            Access to the Portal is provided exclusively to Limited Partners of JBV-sponsored investment vehicles and their
+            expressly authorized representatives. Each User is responsible for maintaining the confidentiality of his, her,
+            or its login credentials and for all activities conducted under such credentials. Unauthorized access to or use
+            of the Portal is strictly prohibited.
+          </p>
+          <p>
+            The Portal contains confidential and proprietary materials relating to JBV investment vehicles, including
+            without limitation financial reports, capital account statements, performance data, and related documents. Such
+            materials are made available solely for informational purposes in connection with your investment relationship
+            with JBV. Nothing contained on the Portal shall constitute investment advice, an offer to sell, or a
+            solicitation of an offer to purchase any security or investment product. You acknowledge that past performance
+            is not indicative of future results and agree that you shall not rely upon the Portal or its contents as a
+            substitute for independent judgment in making investment or financial decisions.
+          </p>
+          <p>
+            You agree to maintain the confidentiality of all information obtained through the Portal and not to disclose
+            such information to any third party without the prior written consent of JBV, except where disclosure is
+            required by applicable law or regulation. You further agree not to attempt to gain unauthorized access to the
+            Portal, to interfere with its operation, or to use the Portal in violation of applicable law.
+          </p>
+          <p>
+            All intellectual property rights in and to the Portal and its content are owned by or licensed to JBV. No right,
+            title, or interest is transferred to you by virtue of access to the Portal, other than the limited right to use
+            the Portal in accordance with these Terms. Any reproduction, distribution, modification, or other use of Portal
+            content without the prior written authorization of JBV is prohibited.
+          </p>
+          <p>
+            To the fullest extent permitted by law, JBV disclaims all liability for any losses, damages, or claims arising
+            out of or relating to your use or inability to use the Portal, including without limitation damages arising from
+            errors, inaccuracies, interruptions, unauthorized access, or delays.
+          </p>
+          <p>
+            JBV reserves the right, in its sole discretion and without notice, to suspend or terminate your access to the
+            Portal in the event of any breach of these Terms or where such action is otherwise deemed necessary or
+            appropriate by JBV.
+          </p>
+          <p>
+            These Terms shall be governed by, and construed in accordance with, the laws of the State of New York, without
+            regard to conflicts of law principles. Any disputes arising hereunder shall be subject to the exclusive
+            jurisdiction of the state and federal courts located within New York County, New York.
+          </p>
+          <p>
+            JBV may amend these Terms at any time, and such amendments shall become effective upon their posting to the
+            Portal. Your continued access to the Portal following the posting of amendments shall constitute your acceptance
+            of the Terms as amended.
+          </p>
+          <p>
+            Inquiries concerning these Terms should be directed to:
+          </p>
+          <address className="not-italic text-sm text-slate-700">
+            <div>JBV Investment Capital – Legal Department</div>
+            <div>405 Lexington Avenue, 32nd Floor</div>
+            <div>New York, NY 10174</div>
+            <div>
+              Email: {" "}
+              <a className="font-semibold text-blue-600 hover:underline" href="mailto:legal@jbvcapital.com">
+                legal@jbvcapital.com
+              </a>
+            </div>
+          </address>
+        </div>
+
+        <section className="mt-10 space-y-4 rounded-2xl bg-white p-6 shadow-sm ring-1 ring-slate-200">
+          <h2 className="text-lg font-semibold text-slate-900">Restricted Access Legal Disclaimer</h2>
+          <p className="text-sm leading-6 text-slate-700">
+            The Limited Partner Portal of JBV Investment Capital (the “Portal”) is a proprietary system intended solely for
+            use by Limited Partners of investment vehicles sponsored or advised by JBV Investment Capital and by those
+            persons who have been expressly authorized by such Limited Partners. Access to and use of the Portal by any
+            other person is strictly prohibited.
+          </p>
+          <p className="text-sm leading-6 text-slate-700">
+            By proceeding beyond this page, you represent and warrant that you are an authorized user of the Portal, that
+            you are accessing the Portal solely in connection with your investment relationship with JBV Investment
+            Capital, and that you will comply with all applicable terms, conditions, and restrictions governing such
+            access.
+          </p>
+          <p className="text-sm leading-6 text-slate-700">
+            The Portal and all information contained herein are confidential and constitute proprietary and trade secret
+            material of JBV Investment Capital. Unauthorized access to, or use of, the Portal or its contents may
+            constitute a violation of applicable laws and regulations, and may subject the violator to civil and criminal
+            penalties. JBV Investment Capital reserves the right to monitor, record, and audit all activity on the Portal
+            and to pursue any remedies available under law or equity in the event of unauthorized use.
+          </p>
+          <p className="text-sm leading-6 text-slate-700">
+            If you are not an authorized user, you must not attempt to access the Portal and are instructed to exit
+            immediately.
+          </p>
+          <p className="text-xs text-slate-500">
+            For information about how JBV Investment Capital handles personal data within the Portal, please consult the {" "}
+            <Link className="font-semibold text-blue-600 hover:underline" href="/privacy-policy">
+              Privacy Policy
+            </Link>
+            .
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/components/site-footer.tsx
+++ b/apps/web/components/site-footer.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+
+export function SiteFooter() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="border-t border-slate-200 bg-white">
+      <div className="mx-auto flex w-full max-w-7xl flex-col items-center justify-between gap-4 px-6 py-6 text-center text-xs text-slate-500 md:flex-row md:text-left">
+        <p className="text-sm text-slate-600">&copy; {year} JBV Investment Capital. All rights reserved.</p>
+        <nav className="flex items-center gap-6 text-sm font-semibold">
+          <Link className="text-blue-600 hover:text-blue-700 hover:underline" href="/privacy-policy">
+            Privacy Policy
+          </Link>
+          <Link className="text-blue-600 hover:text-blue-700 hover:underline" href="/terms-of-use">
+            Terms of Use
+          </Link>
+        </nav>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- add dedicated Privacy Policy and Terms of Use pages detailing effective governance and contact information
- introduce a persistent site footer, login notice, and help center references that surface conspicuous links to the policies
- require limited partners to affirmatively acknowledge the Terms of Use and Privacy Policy before accessing the portal experience

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_b_68cb41690628832088f8d226bae34b9e