### PR TITLE
Adjust LP polling interval to 120 seconds

### DIFF
--- a/apps/web/app/lp/docs/page.tsx
+++ b/apps/web/app/lp/docs/page.tsx
@@ -71,7 +71,9 @@ function getPeriodSortValue(value: any) {
 }
 
 export default function DocumentsPage() {
-  const { data, status, error, initialized, lastUpdated } = usePolling<DocumentsResponse>("/api/lp/documents");
+  const { data, status, error, initialized, lastUpdated } = usePolling<DocumentsResponse>("/api/lp/documents", {
+    interval: 120000,
+  });
   const note = data?.note;
   const noteMessage = useMemo(() => {
     if (note === "contact-not-found") {

--- a/apps/web/app/lp/investments/[id]/page.tsx
+++ b/apps/web/app/lp/investments/[id]/page.tsx
@@ -154,8 +154,12 @@ export default function InvestmentDetailPage() {
   const idParam = params?.id;
   const investmentId = Array.isArray(idParam) ? idParam[0] : idParam;
 
-  const { data, status, error, initialized, lastUpdated } = usePolling<LpDataResponse>("/api/lp/data");
-  const { data: docData } = usePolling<DocumentsResponse>("/api/lp/documents");
+  const { data, status, error, initialized, lastUpdated } = usePolling<LpDataResponse>("/api/lp/data", {
+    interval: 120000,
+  });
+  const { data: docData } = usePolling<DocumentsResponse>("/api/lp/documents", {
+    interval: 120000,
+  });
 
   const record = useMemo(() => {
     return data?.records.find((item) => item.id === investmentId);

--- a/apps/web/app/lp/investments/page.tsx
+++ b/apps/web/app/lp/investments/page.tsx
@@ -150,7 +150,9 @@ function formatValue(key: string, value: any) {
 }
 
 export default function LPInvestmentsPage() {
-  const { data, status, error, initialized, lastUpdated } = usePolling<LpDataResponse>("/api/lp/data");
+  const { data, status, error, initialized, lastUpdated } = usePolling<LpDataResponse>("/api/lp/data", {
+    interval: 120000,
+  });
   const [search, setSearch] = useState("");
 
   const records = useMemo(() => data?.records ?? [], [data?.records]);

--- a/apps/web/app/lp/page.tsx
+++ b/apps/web/app/lp/page.tsx
@@ -144,7 +144,9 @@ function resolveDisplayName(record: ExpandedRecord, fallback = "Unnamed Investme
 }
 
 export default function LPDashboardPage() {
-  const { data, status, error, initialized, lastUpdated } = usePolling<LpDataResponse>("/api/lp/data");
+  const { data, status, error, initialized, lastUpdated } = usePolling<LpDataResponse>("/api/lp/data", {
+    interval: 120000,
+  });
 
   const records = useMemo(() => data?.records ?? [], [data?.records]);
   const metrics = data?.metrics ?? {

--- a/apps/web/app/lp/summary/page.tsx
+++ b/apps/web/app/lp/summary/page.tsx
@@ -214,7 +214,9 @@ function renderFieldValue(recordId: string, field: string, value: any) {
 }
 
 export default function InvestmentSummaryPage() {
-  const { data, status, error, initialized, lastUpdated } = usePolling<SummaryResponse>("/api/lp/summary");
+  const { data, status, error, initialized, lastUpdated } = usePolling<SummaryResponse>("/api/lp/summary", {
+    interval: 120000,
+  });
 
   const fieldOrder = useMemo(() => data?.fieldOrder ?? [], [data?.fieldOrder]);
   const records = useMemo(() => data?.records ?? [], [data?.records]);


### PR DESCRIPTION
## Summary
- update each LP dashboard view to poll Airtable data every 120 seconds instead of the 15 second default

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_b_68cc2263f15c83209e96d49d7b0f3c9b