### PR TITLE
Fix Airtable filter for JBV updates API

### DIFF
--- a/apps/web/app/api/jbv/updates/route.ts
+++ b/apps/web/app/api/jbv/updates/route.ts
@@ -32,7 +32,7 @@ const FIELDS = [
 function buildUrl(searchParams: URLSearchParams) {
   const url = new URL(AIRTABLE_URL);
   url.searchParams.set("view", AIRTABLE_VIEW);
-  url.searchParams.set("filterByFormula", "Portal");
+  url.searchParams.set("filterByFormula", "{Portal}");
   const offset = searchParams.get("offset");
   if (offset) url.searchParams.set("offset", offset);
   FIELDS.forEach((field) => url.searchParams.append("fields[]", field));


### PR DESCRIPTION
## Summary
- ensure the Airtable filter formula references the Portal field correctly to avoid 422 errors when fetching updates

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_b_68cc529e445c8320a8f67ee2a457f6cb