### PR TITLE
Remove Portal filter from JBV updates API

### DIFF
--- a/apps/web/app/api/jbv/updates/route.ts
+++ b/apps/web/app/api/jbv/updates/route.ts
@@ -10,7 +10,6 @@ const AIRTABLE_VIEW = "viwVZZ9vksLZQ8GBG";
 const AIRTABLE_URL = `https://api.airtable.com/v0/${AIRTABLE_BASE}/${AIRTABLE_TABLE}`;
 
 const FIELDS = [
-  "Portal",
   "Post Date",
   "Company",
   "New Investment Button",
@@ -37,7 +36,6 @@ const FIELDS = [
 function buildUrl(searchParams: URLSearchParams) {
   const url = new URL(AIRTABLE_URL);
   url.searchParams.set("view", AIRTABLE_VIEW);
-  url.searchParams.set("filterByFormula", "{Portal}");
   const offset = searchParams.get("offset");
   if (offset) url.searchParams.set("offset", offset);
   FIELDS.forEach((field) => url.searchParams.append("fields[]", field));


### PR DESCRIPTION
## Summary
- stop requesting the deprecated Airtable "Portal" field in the JBV updates API
- rely on the Airtable view configuration for filtering by removing the {Portal} filter formula

## Testing
- pnpm --filter web lint

------
https://chatgpt.com/codex/tasks/task_b_68cd9312e0548320b726a5befc0fba27