### PR TITLE
Fix JBV updates view stability

### DIFF
--- a/apps/web/app/api/jbv/updates/route.ts
+++ b/apps/web/app/api/jbv/updates/route.ts
@@ -9,38 +9,38 @@ const AIRTABLE_VIEW = "viwVZZ9vksLZQ8GBG";
 
 const AIRTABLE_URL = `https://api.airtable.com/v0/${AIRTABLE_BASE}/${AIRTABLE_TABLE}`;
 
-const FIELDS = [
-  "Post Date",
-  "Company",
-  "New Investment Button",
-  "Send Update",
-  "Type",
-  "Data Room",
-  "Subject",
-  "Content",
-  "Content Att",
-  "Contacts",
-  "Target Securities",
-  "Company New",
-  "Stage (from Target Securities)",
-  "Logo (from Target Securities)",
-  "Partner Names",
-  "Partner Emails",
-  "Partner List",
-  "Logo",
-  "Update PDF",
-  "Notes",
-  "Assignee",
-];
+// Optional: re-enable once exact spellings are confirmed
+// const FIELDS = [
+//   "Post Date",
+//   "Company",
+//   "New Investment Button",
+//   "Send Update",
+//   "Type",
+//   "Data Room",
+//   "Subject",
+//   "Content",
+//   "Content Att",
+//   "Contacts",
+//   "Target Securities",
+//   "Company New",
+//   "Stage (from Target Securities)",
+//   "Logo (from Target Securities)",
+//   "Partner Names",
+//   "Partner Emails",
+//   "Partner List",
+//   "Logo",
+//   "Update PDF",
+//   "Notes",
+//   "Assignee",
+// ];
 
 function buildUrl(searchParams: URLSearchParams) {
   const url = new URL(AIRTABLE_URL);
+  // Trust the JBV Portal View for filters/sorting
   url.searchParams.set("view", AIRTABLE_VIEW);
   const offset = searchParams.get("offset");
   if (offset) url.searchParams.set("offset", offset);
-  FIELDS.forEach((field) => url.searchParams.append("fields[]", field));
-  url.searchParams.append("sort[0][field]", "Post Date");
-  url.searchParams.append("sort[0][direction]", "desc");
+  // Defer fields[]/sort until field names are 100% confirmed
   return url.toString();
 }
 
@@ -72,15 +72,18 @@ export async function GET(request: Request) {
 
   const response = await fetchAirtable(url);
   if (!response.ok) {
-    const detailText = await response.text();
+    const text = await response.text();
     try {
-      const parsed = JSON.parse(detailText);
+      const parsed = JSON.parse(text);
       const message =
-        (typeof parsed?.error === "string" && parsed.error) ||
-        (parsed?.error?.message && typeof parsed.error.message === "string" ? parsed.error.message : "Airtable error");
+        typeof parsed?.error?.message === "string"
+          ? parsed.error.message
+          : typeof parsed?.error === "string"
+          ? parsed.error
+          : "Airtable error";
       return NextResponse.json({ error: message, detail: parsed }, { status: response.status });
-    } catch (error) {
-      return NextResponse.json({ error: "Airtable error", detail: detailText }, { status: response.status });
+    } catch {
+      return NextResponse.json({ error: "Airtable error", detail: text }, { status: response.status });
     }
   }
 

--- a/apps/web/components/jbv/UpdatesTab.tsx
+++ b/apps/web/components/jbv/UpdatesTab.tsx
@@ -88,20 +88,24 @@ const initialsFromName = (name?: string) => {
   return `${first?.[0] ?? ""}${last?.[0] ?? ""}`.toUpperCase() || (parts[0]?.slice(0, 2) ?? "JB").toUpperCase();
 };
 
-const renderPlainText = (value: string) => {
-  const safe = value
+function renderPlainText(input: unknown) {
+  const raw = typeof input === "string" ? input : String(input ?? "");
+  const escaped = raw
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
-  const linkified = safe.replace(
+  const linkified = escaped.replace(
     /(https?:\/\/[^\s]+)/g,
-    '<a class="text-blue-600 underline decoration-blue-200 transition hover:text-blue-700" target="_blank" rel="noreferrer noopener" href="$1">$1</a>',
+    '<a class="underline" target="_blank" rel="noreferrer noopener" href="$1">$1</a>',
   );
-  const withBreaks = linkified
-    .replace(/\r?\n\r?\n/g, "</p><p>")
-    .replace(/\r?\n/g, "<br />");
-  return `<p>${withBreaks}</p>`;
-};
+  return (
+    "<p>" +
+    linkified
+      .replace(/\r?\n\r?\n/g, "</p><p>")
+      .replace(/\r?\n/g, "<br/>") +
+    "</p>"
+  );
+}
 
 const resolveCompanyName = (record: AirtableRecord) => {
   const candidates = [
@@ -210,8 +214,11 @@ export default function UpdatesTab() {
         throw new Error(message);
       }
       const data = (await response.json()) as AirtableResponse;
-      setRecords((previous) => (cursor ? [...previous, ...(data.records || [])] : data.records || []));
-      setOffset(data.offset ?? null);
+      if (!data || !Array.isArray(data.records)) {
+        throw new Error("Unexpected response from /api/jbv/updates (no records array)");
+      }
+      setRecords((previous) => (cursor ? [...previous, ...data.records] : data.records));
+      setOffset(typeof data.offset === "string" ? data.offset : null);
     } catch (err: any) {
       setError(err?.message || "Unable to load updates");
     } finally {
@@ -310,7 +317,8 @@ function UpdateCard({ record }: { record: AirtableRecord }) {
   const typeList = toTextArray(field(record, "Type"));
   const postDate = field(record, "Post Date") as string | undefined;
   const companyName = useMemo(() => resolveCompanyName(record), [record]);
-  const content = field(record, "Content") as string | undefined;
+  const rawContent = field(record, "Content");
+  const content = typeof rawContent === "string" ? rawContent : undefined;
   const dataRoom = ensureHttp(field(record, "Data Room") as string | undefined);
   const updatePdf = (() => {
     const attachments = field(record, "Update PDF");
@@ -322,21 +330,19 @@ function UpdateCard({ record }: { record: AirtableRecord }) {
     }
     return undefined;
   })();
+  const rawContentAttachments = field(record, "Content Att");
   const contentAttachments = useMemo(() => {
-    const attachments = field(record, "Content Att");
-    if (Array.isArray(attachments)) {
-      return attachments.filter((item): item is AirtableAttachment => Boolean(item && typeof item === "object" && "url" in item));
-    }
-    return [];
-  }, [record]);
+    const attachments = Array.isArray(rawContentAttachments) ? rawContentAttachments : [];
+    return attachments.filter((item): item is AirtableAttachment => Boolean(item && typeof item === "object" && "url" in item));
+  }, [rawContentAttachments]);
   const partnerNames = toTextArray(field(record, "Partner Names"));
   const partnerEmails = toTextArray(field(record, "Partner Emails"));
   const contactNames = toTextArray(field(record, "Contacts"));
   const partnerList = toTextArray(field(record, "Partner List"));
 
   const preview = useMemo(() => getPreviewText(content), [content]);
-
-  const summaryHtml = useMemo(() => (content ? renderPlainText(content) : null), [content]);
+  const summaryHtml = useMemo(() => (typeof content === "string" && content.trim() ? renderPlainText(content) : null), [content]);
+  const hasContent = typeof content === "string" && content.trim().length > 0;
 
   const showPartnerSection = partnerNames.length > 0 || partnerEmails.length > 0 || partnerList.length > 0 || contactNames.length > 0;
 
@@ -373,7 +379,7 @@ function UpdateCard({ record }: { record: AirtableRecord }) {
           </div>
         </div>
         <div className="flex flex-1 flex-col gap-4 px-6 py-5">
-          {preview && (
+          {hasContent && preview && (
             <div className="space-y-2">
               <p className="text-sm text-slate-600">{preview}</p>
               <motion.button


### PR DESCRIPTION
## Summary
- stop forcing a Portal filter and risky field selections in the JBV updates API so Airtable view controls the records, and bubble up cleaner error messages
- harden the Updates tab rendering by escaping text, guarding attachment arrays, and only expanding summaries when valid content is returned

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_b_68cd9bd5368883208883732b6d9b60e1